### PR TITLE
Add a missing decorator for state().

### DIFF
--- a/virl2_client/models/lab.py
+++ b/virl2_client/models/lab.py
@@ -795,6 +795,7 @@ class Lab:
             self.wait_until_lab_converged()
         logger.debug("started lab: %s", self._lab_id)
 
+    @property
     def state(self):
         """
         Returns the state of the lab.

--- a/virl2_client/models/lab.py
+++ b/virl2_client/models/lab.py
@@ -795,7 +795,6 @@ class Lab:
             self.wait_until_lab_converged()
         logger.debug("started lab: %s", self._lab_id)
 
-    @property
     def state(self):
         """
         Returns the state of the lab.
@@ -812,7 +811,7 @@ class Lab:
     def is_active(self):
         "Returns if the lab is running."
         simulated_states = {"STARTED", "QUEUED", "BOOTED"}
-        return self.state in simulated_states
+        return self.state() in simulated_states
 
     def details(self):
         """


### PR DESCRIPTION
Without this, is_active() fails since lab.state is a pointer to a method
and not the property itself.