### PR TITLE
Add client/server version comparison dunder methods

### DIFF
--- a/tests/test_client_library.py
+++ b/tests/test_client_library.py
@@ -362,7 +362,6 @@ def test_exact_version_no_warn(client_library_exact_version, caplog):
         pytest.param(Version("2.0.0"), Version("2.10.0"), False, id="Minor is much lesser than"),
         pytest.param(Version("2.0.0"), Version("3.0.0"), False, id="Major is lesser than"),
         pytest.param(Version("2.0.0"), Version("10.0.0"), False, id="Major is much lesser than"),
-        pytest.param(Version("2.0.0"), Version("10.0.0"), False, id="Major is much lesser than"),
         pytest.param(Version("2.0.0"), "random string", False, id="Other object is string and not a Version object"),
         pytest.param(Version("2.0.0"), 12345, False, id="Other object is int and not a Version object")
     ]
@@ -395,6 +394,54 @@ def test_version_comparison_greater_than(greater, lesser, expected):
 )
 def test_version_comparison_greater_than_or_equal_to(first, second, expected):
     assert (first >= second) == expected
+
+@pytest.mark.parametrize(
+    "lesser, greater, expected",
+    [
+        pytest.param(Version("2.0.0"), Version("2.0.1"), True, id="Patch is less than"),
+        pytest.param(Version("2.0.0"), Version("2.0.10"), True, id="Patch is much less than"),
+        pytest.param(Version("2.0.0"), Version("2.1.0"), True, id="Minor is less than"),
+        pytest.param(Version("2.0.0"), Version("2.10.0"), True, id="Minor is much less than"),
+        pytest.param(Version("2.0.0"), Version("3.0.0"), True, id="Major is less than"),
+        pytest.param(Version("2.0.0"), Version("10.0.0"), True, id="Major is much less than"),
+        pytest.param(Version("2.0.1"), Version("2.0.0"), False, id="Patch is greater than"),
+        pytest.param(Version("2.0.10"), Version("2.0.0"), False, id="Patch is much greater than"),
+        pytest.param(Version("2.1.0"), Version("2.0.0"), False, id="Minor is greater than"),
+        pytest.param(Version("2.10.0"), Version("2.0.0"), False, id="Minor is much greater than"),
+        pytest.param(Version("3.0.0"), Version("2.0.0"), False, id="Major is greater than"),
+        pytest.param(Version("10.0.0"), Version("2.0.0"), False, id="Major is much greater than"),
+        pytest.param(Version("2.0.0"), "random string", False, id="Other object is string and not a Version object"),
+        pytest.param(Version("2.0.0"), 12345, False, id="Other object is int and not a Version object")
+    ]
+)
+def test_version_comparison_less_than(lesser, greater, expected):
+    assert (lesser < greater) == expected
+
+@pytest.mark.parametrize(
+    "first, second, expected",
+    [
+        pytest.param(Version("2.0.0"), Version("2.0.1"), True, id="Patch is less than"),
+        pytest.param(Version("2.0.0"), Version("2.0.10"), True, id="Patch is much less than"),
+        pytest.param(Version("2.0.0"), Version("2.1.0"), True, id="Minor is less than"),
+        pytest.param(Version("2.0.0"), Version("2.10.0"), True, id="Minor is much less than"),
+        pytest.param(Version("2.0.0"), Version("3.0.0"), True, id="Major is less than"),
+        pytest.param(Version("2.0.0"), Version("10.0.0"), True, id="Major is much less than"),
+        pytest.param(Version("2.0.1"), Version("2.0.0"), False, id="Patch is greater than"),
+        pytest.param(Version("2.0.10"), Version("2.0.0"), False, id="Patch is much greater than"),
+        pytest.param(Version("2.1.0"), Version("2.0.0"), False, id="Minor is greater than"),
+        pytest.param(Version("2.10.0"), Version("2.0.0"), False, id="Minor is much greater than"),
+        pytest.param(Version("3.0.0"), Version("2.0.0"), False, id="Major is greater than"),
+        pytest.param(Version("10.0.0"), Version("2.0.0"), False, id="Major is much greater than"),
+        pytest.param(Version("2.0.0"), Version("2.0.0"), True, id="Equal versions no minor no patch"),
+        pytest.param(Version("2.0.1"), Version("2.0.1"), True, id="Equal versions patch increment"),
+        pytest.param(Version("2.1.0"), Version("2.1.0"), True, id="Equal versions minor increment"),
+        pytest.param(Version("3.0.0"), Version("3.0.0"), True, id="Equal versions major increment"),
+        pytest.param(Version("2.0.0"), "random string", False, id="Other object is string and not a Version object"),
+        pytest.param(Version("2.0.0"), 12345, False, id="Other object is int and not a Version object"),
+    ]
+)
+def test_version_comparison_less_than_or_equal_to(first, second, expected):
+    assert (first <= second) == expected
 
 def test_import_lab_offline(
     client_library_compatible_version, mocked_session, tmp_path: Path

--- a/tests/test_client_library.py
+++ b/tests/test_client_library.py
@@ -363,6 +363,8 @@ def test_exact_version_no_warn(client_library_exact_version, caplog):
         pytest.param(Version("2.0.0"), Version("3.0.0"), False, id="Major is lesser than"),
         pytest.param(Version("2.0.0"), Version("10.0.0"), False, id="Major is much lesser than"),
         pytest.param(Version("2.0.0"), Version("10.0.0"), False, id="Major is much lesser than"),
+        pytest.param(Version("2.0.0"), "random string", False, id="Other object is string and not a Version object"),
+        pytest.param(Version("2.0.0"), 12345, False, id="Other object is int and not a Version object")
     ]
 )
 def test_version_comparison_greater_than(greater, lesser, expected):
@@ -387,6 +389,8 @@ def test_version_comparison_greater_than(greater, lesser, expected):
         pytest.param(Version("2.0.1"), Version("2.0.1"), True, id="Equal versions patch increment"),
         pytest.param(Version("2.1.0"), Version("2.1.0"), True, id="Equal versions minor increment"),
         pytest.param(Version("3.0.0"), Version("3.0.0"), True, id="Equal versions major increment"),
+        pytest.param(Version("2.0.0"), "random string", False, id="Other object is string and not a Version object"),
+        pytest.param(Version("2.0.0"), 12345, False, id="Other object is int and not a Version object")
     ]
 )
 def test_version_comparison_greater_than_or_equal_to(first, second, expected):

--- a/tests/test_client_library.py
+++ b/tests/test_client_library.py
@@ -347,6 +347,29 @@ def test_exact_version_no_warn(client_library_exact_version, caplog):
     )
 
 
+@pytest.mark.parametrize(
+    "greater, lesser, expected",
+    [
+        pytest.param("2.0.1", "2.0.0", True, id="Patch is greater than"),
+        pytest.param("2.0.10", "2.0.0", True, id="Patch is much greater than"),
+        pytest.param("2.1.0", "2.0.0", True, id="Minor is greater than"),
+        pytest.param("2.10.0", "2.0.0", True, id="Minor is much greater than"),
+        pytest.param("3.0.0", "2.0.0", True, id="Major is greater than"),
+        pytest.param("10.0.0", "2.0.0", True, id="Major is much greater than"),
+        pytest.param("2.0.0", "2.0.1", False, id="Patch is lesser than"),
+        pytest.param("2.0.0", "2.0.10", False, id="Patch is much lesser than"),
+        pytest.param("2.0.0", "2.1.0", False, id="Minor is lesser than"),
+        pytest.param("2.0.0", "2.10.0", False, id="Minor is much lesser than"),
+        pytest.param("2.0.0", "3.0.0", False, id="Major is lesser than"),
+        pytest.param("2.0.0", "10.0.0", False, id="Major is much lesser than"),
+    ]
+)
+def test_version_comparison_greater_than(greater, lesser, expected):
+    greater_obj = Version(greater)
+    lesser_obj = Version(lesser)
+    assert (greater_obj > lesser_obj) == expected
+
+
 def test_import_lab_offline(
     client_library_compatible_version, mocked_session, tmp_path: Path
 ):

--- a/tests/test_client_library.py
+++ b/tests/test_client_library.py
@@ -350,50 +350,47 @@ def test_exact_version_no_warn(client_library_exact_version, caplog):
 @pytest.mark.parametrize(
     "greater, lesser, expected",
     [
-        pytest.param("2.0.1", "2.0.0", True, id="Patch is greater than"),
-        pytest.param("2.0.10", "2.0.0", True, id="Patch is much greater than"),
-        pytest.param("2.1.0", "2.0.0", True, id="Minor is greater than"),
-        pytest.param("2.10.0", "2.0.0", True, id="Minor is much greater than"),
-        pytest.param("3.0.0", "2.0.0", True, id="Major is greater than"),
-        pytest.param("10.0.0", "2.0.0", True, id="Major is much greater than"),
-        pytest.param("2.0.0", "2.0.1", False, id="Patch is lesser than"),
-        pytest.param("2.0.0", "2.0.10", False, id="Patch is much lesser than"),
-        pytest.param("2.0.0", "2.1.0", False, id="Minor is lesser than"),
-        pytest.param("2.0.0", "2.10.0", False, id="Minor is much lesser than"),
-        pytest.param("2.0.0", "3.0.0", False, id="Major is lesser than"),
-        pytest.param("2.0.0", "10.0.0", False, id="Major is much lesser than"),
+        pytest.param(Version("2.0.1"), Version("2.0.0"), True, id="Patch is greater than"),
+        pytest.param(Version("2.0.10"), Version("2.0.0"), True, id="Patch is much greater than"),
+        pytest.param(Version("2.1.0"), Version("2.0.0"), True, id="Minor is greater than"),
+        pytest.param(Version("2.10.0"), Version("2.0.0"), True, id="Minor is much greater than"),
+        pytest.param(Version("3.0.0"), Version("2.0.0"), True, id="Major is greater than"),
+        pytest.param(Version("10.0.0"), Version("2.0.0"), True, id="Major is much greater than"),
+        pytest.param(Version("2.0.0"), Version("2.0.1"), False, id="Patch is lesser than"),
+        pytest.param(Version("2.0.0"), Version("2.0.10"), False, id="Patch is much lesser than"),
+        pytest.param(Version("2.0.0"), Version("2.1.0"), False, id="Minor is lesser than"),
+        pytest.param(Version("2.0.0"), Version("2.10.0"), False, id="Minor is much lesser than"),
+        pytest.param(Version("2.0.0"), Version("3.0.0"), False, id="Major is lesser than"),
+        pytest.param(Version("2.0.0"), Version("10.0.0"), False, id="Major is much lesser than"),
+        pytest.param(Version("2.0.0"), Version("10.0.0"), False, id="Major is much lesser than"),
     ]
 )
 def test_version_comparison_greater_than(greater, lesser, expected):
-    greater_obj = Version(greater)
-    lesser_obj = Version(lesser)
-    assert (greater_obj > lesser_obj) == expected
+    assert (greater > lesser) == expected
 
 @pytest.mark.parametrize(
     "first, second, expected",
     [
-        pytest.param("2.0.1", "2.0.0", True, id="Patch is greater than"),
-        pytest.param("2.0.10", "2.0.0", True, id="Patch is much greater than"),
-        pytest.param("2.1.0", "2.0.0", True, id="Minor is greater than"),
-        pytest.param("2.10.0", "2.0.0", True, id="Minor is much greater than"),
-        pytest.param("3.0.0", "2.0.0", True, id="Major is greater than"),
-        pytest.param("10.0.0", "2.0.0", True, id="Major is much greater than"),
-        pytest.param("2.0.0", "2.0.1", False, id="Patch is lesser than"),
-        pytest.param("2.0.0", "2.0.10", False, id="Patch is much lesser than"),
-        pytest.param("2.0.0", "2.1.0", False, id="Minor is lesser than"),
-        pytest.param("2.0.0", "2.10.0", False, id="Minor is much lesser than"),
-        pytest.param("2.0.0", "3.0.0", False, id="Major is lesser than"),
-        pytest.param("2.0.0", "10.0.0", False, id="Major is much lesser than"),
-        pytest.param("2.0.0", "2.0.0", True, id="Equal versions no minor no patch"),
-        pytest.param("2.0.1", "2.0.1", True, id="Equal versions patch increment"),
-        pytest.param("2.1.0", "2.1.0", True, id="Equal versions minor increment"),
-        pytest.param("3.0.0", "3.0.0", True, id="Equal versions major increment"),
+        pytest.param(Version("2.0.1"), Version("2.0.0"), True, id="Patch is greater than"),
+        pytest.param(Version("2.0.10"), Version("2.0.0"), True, id="Patch is much greater than"),
+        pytest.param(Version("2.1.0"), Version("2.0.0"), True, id="Minor is greater than"),
+        pytest.param(Version("2.10.0"), Version("2.0.0"), True, id="Minor is much greater than"),
+        pytest.param(Version("3.0.0"), Version("2.0.0"), True, id="Major is greater than"),
+        pytest.param(Version("10.0.0"), Version("2.0.0"), True, id="Major is much greater than"),
+        pytest.param(Version("2.0.0"), Version("2.0.1"), False, id="Patch is lesser than"),
+        pytest.param(Version("2.0.0"), Version("2.0.10"), False, id="Patch is much lesser than"),
+        pytest.param(Version("2.0.0"), Version("2.1.0"), False, id="Minor is lesser than"),
+        pytest.param(Version("2.0.0"), Version("2.10.0"), False, id="Minor is much lesser than"),
+        pytest.param(Version("2.0.0"), Version("3.0.0"), False, id="Major is lesser than"),
+        pytest.param(Version("2.0.0"), Version("10.0.0"), False, id="Major is much lesser than"),
+        pytest.param(Version("2.0.0"), Version("2.0.0"), True, id="Equal versions no minor no patch"),
+        pytest.param(Version("2.0.1"), Version("2.0.1"), True, id="Equal versions patch increment"),
+        pytest.param(Version("2.1.0"), Version("2.1.0"), True, id="Equal versions minor increment"),
+        pytest.param(Version("3.0.0"), Version("3.0.0"), True, id="Equal versions major increment"),
     ]
 )
 def test_version_comparison_greater_than_or_equal_to(first, second, expected):
-    first_obj = Version(first)
-    second_obj = Version(second)
-    assert (first_obj >= second_obj) == expected
+    assert (first >= second) == expected
 
 def test_import_lab_offline(
     client_library_compatible_version, mocked_session, tmp_path: Path

--- a/tests/test_client_library.py
+++ b/tests/test_client_library.py
@@ -369,6 +369,31 @@ def test_version_comparison_greater_than(greater, lesser, expected):
     lesser_obj = Version(lesser)
     assert (greater_obj > lesser_obj) == expected
 
+@pytest.mark.parametrize(
+    "first, second, expected",
+    [
+        pytest.param("2.0.1", "2.0.0", True, id="Patch is greater than"),
+        pytest.param("2.0.10", "2.0.0", True, id="Patch is much greater than"),
+        pytest.param("2.1.0", "2.0.0", True, id="Minor is greater than"),
+        pytest.param("2.10.0", "2.0.0", True, id="Minor is much greater than"),
+        pytest.param("3.0.0", "2.0.0", True, id="Major is greater than"),
+        pytest.param("10.0.0", "2.0.0", True, id="Major is much greater than"),
+        pytest.param("2.0.0", "2.0.1", False, id="Patch is lesser than"),
+        pytest.param("2.0.0", "2.0.10", False, id="Patch is much lesser than"),
+        pytest.param("2.0.0", "2.1.0", False, id="Minor is lesser than"),
+        pytest.param("2.0.0", "2.10.0", False, id="Minor is much lesser than"),
+        pytest.param("2.0.0", "3.0.0", False, id="Major is lesser than"),
+        pytest.param("2.0.0", "10.0.0", False, id="Major is much lesser than"),
+        pytest.param("2.0.0", "2.0.0", True, id="Equal versions no minor no patch"),
+        pytest.param("2.0.1", "2.0.1", True, id="Equal versions patch increment"),
+        pytest.param("2.1.0", "2.1.0", True, id="Equal versions minor increment"),
+        pytest.param("3.0.0", "3.0.0", True, id="Equal versions major increment"),
+    ]
+)
+def test_version_comparison_greater_than_or_equal_to(first, second, expected):
+    first_obj = Version(first)
+    second_obj = Version(second)
+    assert (first_obj >= second_obj) == expected
 
 def test_import_lab_offline(
     client_library_compatible_version, mocked_session, tmp_path: Path

--- a/virl2_client/virl2_client.py
+++ b/virl2_client/virl2_client.py
@@ -52,9 +52,9 @@ class Version(object):
     def __init__(self, version_str):
         self.version_str = version_str
         version_list = self.version_str.split(".")
-        self.major = version_list[0]
-        self.minor = version_list[1]
-        self.patch = version_list[2]
+        self.major = int(version_list[0])
+        self.minor = int(version_list[1])
+        self.patch = int(version_list[2])
 
     def __repr__(self):
         return "{}".format(self.version_str)
@@ -65,6 +65,18 @@ class Version(object):
             and self.minor == other.minor
             and self.patch == other.patch
         )
+
+    def __gt__(self, other):
+        if isinstance(other, self.__class__):
+            if self.major > other.major:
+                return True
+            elif self.major == other.major:
+                if self.minor > other.minor:
+                    return True
+                elif self.minor == other.minor:
+                    if self.patch > other.patch:
+                        return True
+        return False
 
     def major_differs(self, other):
         return self.major != other.major

--- a/virl2_client/virl2_client.py
+++ b/virl2_client/virl2_client.py
@@ -77,6 +77,9 @@ class Version(object):
                     if self.patch > other.patch:
                         return True
         return False
+    
+    def __ge__(self, other):
+        return (self == other or self > other)
 
     def major_differs(self, other):
         return self.major != other.major

--- a/virl2_client/virl2_client.py
+++ b/virl2_client/virl2_client.py
@@ -83,6 +83,21 @@ class Version(object):
     def __ge__(self, other):
         return (self == other or self > other)
 
+    def __lt__(self, other):
+        if isinstance(other, self.__class__):
+            if self.major < other.major:
+                return True
+            elif self.major == other.major:
+                if self.minor < other.minor:
+                    return True
+                elif self.minor == other.minor:
+                    if self.patch < other.patch:
+                        return True
+        return False
+
+    def __le__(self, other):
+        return (self == other or self < other)
+
     def major_differs(self, other):
         return self.major != other.major
 

--- a/virl2_client/virl2_client.py
+++ b/virl2_client/virl2_client.py
@@ -60,11 +60,13 @@ class Version(object):
         return "{}".format(self.version_str)
 
     def __eq__(self, other):
-        return (
-            self.major == other.major
-            and self.minor == other.minor
-            and self.patch == other.patch
-        )
+        if isinstance(other, self.__class__):
+            return (
+                self.major == other.major
+                and self.minor == other.minor
+                and self.patch == other.patch
+            )
+        return False
 
     def __gt__(self, other):
         if isinstance(other, self.__class__):


### PR DESCRIPTION
This PR adds the following dunder methods to the virl2_client.Version class that allows for comparison of major, minor, and patch versions between two Version objects:

* `__gt__`
* `__ge__`
* `__lt__`
* `__le__`

Furthermore, the existing `__eq__` dunder method is slightly modified to check the compared object's class prior to performing any comparison of major, minor, or patch versions.

All unit tests are passing. Further unit tests have been added for each new method covering common use cases and expected failure scenarios.