### PR TITLE
updated node.py to only add single tags when add_tag() is called

### DIFF
--- a/virl2_client/models/node.py
+++ b/virl2_client/models/node.py
@@ -429,8 +429,10 @@ class Node:
 
     def add_tag(self, tag):
         current = self._tags
-        current.append(tag)
-        self._set_node_property("tags", current)
+        if tag not in current:
+            current.append(tag)
+            # Push single tag to API
+            self._set_node_property("tags", [tag])
 
     def remove_tag(self, tag):
         current = self._tags


### PR DESCRIPTION
Fix for issue #8.

Modified add_tag() to only push a single tag at a time to the API.