### PR TITLE
Return lab status in ClientLibrary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 docs/build/*
 *.pyc
 *.egg-info
+venv

--- a/virl2_client/virl2_client.py
+++ b/virl2_client/virl2_client.py
@@ -708,3 +708,27 @@ class ClientLibrary:
         response = self.session.get(url)
         response.raise_for_status()
         return response.json()
+    
+    def get_all_labs_status(self, show_all: bool=False) -> list:
+        """
+        Retrieves a list of all defined labs and their status.
+
+        :param show_all: Whether to get only labs owned by the admin or all user labs
+        :type show_all: bool
+        :returns: A list of tuples
+        :rtype: list[tuple]
+        """
+        # TODO: integrate this further with local labs - check if already exist
+        url = "labs"
+        if show_all:
+            url += "?show_all=true"
+        url = urljoin(self._base_url, url)
+        response = self.session.get(url)
+        response.raise_for_status()
+        lab_ids = response.json()
+        labs = []
+        for lab_id in lab_ids:
+            lab = self.join_existing_lab(lab_id)
+            labs.append((lab_id, lab.title, lab.state()))
+        
+        return labs

--- a/virl2_client/virl2_client.py
+++ b/virl2_client/virl2_client.py
@@ -715,7 +715,7 @@ class ClientLibrary:
 
         :param show_all: Whether to get only labs owned by the admin or all user labs
         :type show_all: bool
-        :returns: A list of tuples
+        :returns: A list of tuples of Lab IDs, title and status
         :rtype: list[tuple]
         """
         # TODO: integrate this further with local labs - check if already exist


### PR DESCRIPTION
## What does this PR do?

When using the `virl2_client.virl2_client.ClientLibrary` you are able to return all labs in a list and the labs as a list of lab objects. The issue is that when you return all labs it would great to also have the status. 

## Recommendations for how to test this, or anything you are worried about?

I thought about implementing this in the `get_lab_list()` since it already returns a list. But it only returns a list of lab IDs.