### PR TITLE
SIMPLE-6105 node.remove no longer always raises NodeNotFound

### DIFF
--- a/virl2_client/models/node.py
+++ b/virl2_client/models/node.py
@@ -750,7 +750,6 @@ class Node:
         url = self._url_for("vnc_key")
         return self._session.get(url).json()
 
-    @check_stale
     def remove(self) -> None:
         """Remove the node from the system."""
         self.lab.remove_node(self)


### PR DESCRIPTION
Also omitted the rather useless `owner` argument. Only added it in the first place because `property.__get__` returned it, but it was completely unnecessary in hindsight.