### PR TITLE
SIMPLE-6776 local groups should still work with unset group filter

### DIFF
--- a/virl2_client/models/groups.py
+++ b/virl2_client/models/groups.py
@@ -98,8 +98,8 @@ class GroupManagement:
         """
         data = {
             "name": name,
-            "description": description,
-            "members": members or [],
+            **({"description": description} if description else {}),
+            **({"members": members} if members else {}),
             "labs": labs or [],
         }
         url = self._url_for("groups")


### PR DESCRIPTION
fix for create_group to not send description and members if not specified since ldap groups don't allow those args