### PR TITLE
Removed unexpected behavior of import lab method

### DIFF
--- a/virl2_client/virl2_client.py
+++ b/virl2_client/virl2_client.py
@@ -542,13 +542,6 @@ class ClientLibrary:
         :raises httpx.HTTPError: If there was a transport error.
         """
         _deprecated_argument(self.import_lab, offline, "offline")
-
-        if title is not None:
-            for lab_id in self._labs:
-                if (lab := self._labs[lab_id]).title == title:
-                    # Lab of this title already exists, sync and return it
-                    lab.sync()
-                    return lab
         lab = self._create_imported_lab(topology, title, virl_1x)
         lab.sync()
         self._labs[lab.id] = lab


### PR DESCRIPTION
When a lab with a specific title existed on a CML instance, we joined that lab instead of creating a new lab with the same title which would had been perfectly fine.  I believe that this was some obsolete feature request from pre-CML 2.0 era where labs possibly were enforced to have unique titles.

This feature requests was in my opinion by mistake delivered in CML 2.7.0 and should be removed.  More importantly, it is causing harm when working with deleted labs #120.