### PR TITLE
Add support for a starting index when connecting nodes.

### DIFF
--- a/virl2_client/models/lab.py
+++ b/virl2_client/models/lab.py
@@ -867,16 +867,17 @@ class Lab:
 
     @check_stale
     @locked
-    def connect_two_nodes(self, node1: Node, node2: Node) -> Link:
+    def connect_two_nodes(self, node1: Node, node2: Node, index: int = 0) -> Link:
         """
         Connect two nodes within a lab.
 
         :param node1: The first node object.
         :param node2: The second node object.
+        :param index: An optional starting interface index (default: 0).
         :returns: The created link.
         """
-        iface1 = node1.next_available_interface() or node1.create_interface()
-        iface2 = node2.next_available_interface() or node2.create_interface()
+        iface1 = node1.next_available_interface(index) or node1.create_interface()
+        iface2 = node2.next_available_interface(index) or node2.create_interface()
         return self.create_link(iface1, iface2)
 
     @check_stale

--- a/virl2_client/models/node.py
+++ b/virl2_client/models/node.py
@@ -234,7 +234,7 @@ class Node:
         return self.lab.create_interface(self, slot, wait=wait)
 
     @locked
-    def next_available_interface(self) -> Interface | None:
+    def next_available_interface(self, index: int = 0) -> Interface | None:
         """
         Return the next available physical interface on this node.
 
@@ -242,10 +242,11 @@ class Node:
         as "do not use"... Only the third physical interface can be used
         to connect to other nodes!
 
+        :param index: An optional starting interface index (default: 0).
         :returns: An available physical interface or None if all existing
             ones are connected.
         """
-        for iface in self.interfaces():
+        for iface in enumerate(self.interfaces(), index):
             if not iface.connected and iface.physical:
                 return iface
         return None

--- a/virl2_client/models/node.py
+++ b/virl2_client/models/node.py
@@ -246,7 +246,7 @@ class Node:
         :returns: An available physical interface or None if all existing
             ones are connected.
         """
-        for iface in enumerate(self.interfaces(), index):
+        for _, iface in enumerate(self.interfaces(), index):
             if not iface.connected and iface.physical:
                 return iface
         return None


### PR DESCRIPTION
By default, the `lab.connect_two_nodes()` connects the next two
available indexes.  Extend this to allow an index where you can start
at, for example, 1.  This could allow to skip mgmt interfaces.