### PR TITLE
SIMPLE-7926-pcl-does-not-store-some-node-and-interface-operational-data

### DIFF
--- a/virl2_client/models/node.py
+++ b/virl2_client/models/node.py
@@ -923,7 +923,7 @@ class Node:
             it can be passed here to save an API call. Will be fetched automatically
             otherwise.
         """
-        if not response:
+        if response is None:
             url = self._url_for("operational")
             response = self._session.get(url).json()
         if response is None:

--- a/virl2_client/models/system.py
+++ b/virl2_client/models/system.py
@@ -94,6 +94,7 @@ class SystemManagement:
             (should never be the case).
         :returns: The controller object.
         """
+        self.sync_compute_hosts_if_outdated()
         for compute_host in self._compute_hosts.values():
             if compute_host.is_connector:
                 return compute_host


### PR DESCRIPTION
> SIMPLE-7926: PCL does not store some node and interface operational data
> SIMPLE-7927: PCL system management controller property does not trigger compute load