### PR TITLE
Convert relative imports to absolute imports

### DIFF
--- a/virl2_client/__init__.py
+++ b/virl2_client/__init__.py
@@ -19,8 +19,13 @@
 #
 """Python client library for the Cisco Modeling Labs (CML) REST API."""
 
-from .exceptions import InterfaceNotFound, LabNotFound, LinkNotFound, NodeNotFound
-from .virl2_client import ClientConfig, ClientLibrary, InitializationError
+from virl2_client.exceptions import (
+    InterfaceNotFound,
+    LabNotFound,
+    LinkNotFound,
+    NodeNotFound,
+)
+from virl2_client.virl2_client import ClientConfig, ClientLibrary, InitializationError
 
 __all__ = [
     "InterfaceNotFound",

--- a/virl2_client/event_handling.py
+++ b/virl2_client/event_handling.py
@@ -26,11 +26,11 @@ from abc import ABC, abstractmethod
 from os import name as os_name
 from typing import TYPE_CHECKING, Any
 
-from .exceptions import ElementNotFound, LabNotFound
+from virl2_client.exceptions import ElementNotFound, LabNotFound
 
 if TYPE_CHECKING:
-    from ..virl2_client import ClientLibrary
-    from .models import Interface, Lab, Link, Node
+    from virl2_client.models import Interface, Lab, Link, Node
+    from virl2_client.virl2_client import ClientLibrary
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/virl2_client/event_listening.py
+++ b/virl2_client/event_listening.py
@@ -31,10 +31,10 @@ from urllib.parse import urlparse
 
 import aiohttp
 
-from .event_handling import Event, EventHandler
+from virl2_client.event_handling import Event, EventHandler
 
 if TYPE_CHECKING:
-    from .virl2_client import ClientLibrary
+    from virl2_client.virl2_client import ClientLibrary
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/virl2_client/models/__init__.py
+++ b/virl2_client/models/__init__.py
@@ -22,21 +22,21 @@ labs, nodes, interfaces and links. It also contains classes for
 node and image definition and helper classes for automation
 and authentication."""
 
-from .annotation import Annotation
-from .auth_management import AuthManagement
-from .authentication import TokenAuth
-from .group import GroupManagement
-from .interface import Interface
-from .lab import Lab
-from .lab_repository import LabRepository, LabRepositoryManagement
-from .licensing import Licensing
-from .link import Link
-from .node import Node
-from .node_image_definition import NodeImageDefinitions
-from .resource_pool import ResourcePoolManagement
-from .smart_annotation import SmartAnnotation
-from .system import SystemManagement
-from .user import UserManagement
+from virl2_client.models.annotation import Annotation
+from virl2_client.models.auth_management import AuthManagement
+from virl2_client.models.authentication import TokenAuth
+from virl2_client.models.group import GroupManagement
+from virl2_client.models.interface import Interface
+from virl2_client.models.lab import Lab
+from virl2_client.models.lab_repository import LabRepository, LabRepositoryManagement
+from virl2_client.models.licensing import Licensing
+from virl2_client.models.link import Link
+from virl2_client.models.node import Node
+from virl2_client.models.node_image_definition import NodeImageDefinitions
+from virl2_client.models.resource_pool import ResourcePoolManagement
+from virl2_client.models.smart_annotation import SmartAnnotation
+from virl2_client.models.system import SystemManagement
+from virl2_client.models.user import UserManagement
 
 __all__ = (
     "Interface",

--- a/virl2_client/models/annotation.py
+++ b/virl2_client/models/annotation.py
@@ -23,14 +23,14 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, Literal
 
-from ..exceptions import InvalidProperty
-from ..utils import check_stale, get_url_from_template, locked
-from ..utils import property_s as property
+from virl2_client.exceptions import InvalidProperty
+from virl2_client.utils import check_stale, get_url_from_template, locked
+from virl2_client.utils import property_s as property
 
 if TYPE_CHECKING:
     import httpx
 
-    from .lab import Lab
+    from virl2_client.models.lab import Lab
 
     AnnotationTypeString = Literal["text", "line", "ellipse", "rectangle"]
     AnnotationType = (

--- a/virl2_client/models/auth_management.py
+++ b/virl2_client/models/auth_management.py
@@ -23,9 +23,9 @@ from __future__ import annotations
 import time
 from typing import TYPE_CHECKING, Any
 
-from ..exceptions import MethodNotActive
-from ..utils import get_url_from_template
-from .resource_pool import ResourcePool
+from virl2_client.exceptions import MethodNotActive
+from virl2_client.models.resource_pool import ResourcePool
+from virl2_client.utils import get_url_from_template
 
 if TYPE_CHECKING:
     from httpx import Client

--- a/virl2_client/models/authentication.py
+++ b/virl2_client/models/authentication.py
@@ -28,12 +28,12 @@ from uuid import uuid4
 
 import httpx
 
-from ..exceptions import APIError
+from virl2_client.exceptions import APIError
 
 _LOGGER = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from ..virl2_client import ClientLibrary
+    from virl2_client.virl2_client import ClientLibrary
 
 
 _AUTH_URL = "authenticate"

--- a/virl2_client/models/cl_pyats.py
+++ b/virl2_client/models/cl_pyats.py
@@ -42,13 +42,13 @@ else:
     _PyatsProcessor.argv.clear()
 
 
-from ..exceptions import PyatsDeviceNotFound, PyatsNotInstalled
+from virl2_client.exceptions import PyatsDeviceNotFound, PyatsNotInstalled
 
 if TYPE_CHECKING:
     from genie.libs.conf.device import Device
     from genie.libs.conf.testbed import Testbed
 
-    from .lab import Lab
+    from virl2_client.models.lab import Lab
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/virl2_client/models/group.py
+++ b/virl2_client/models/group.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from ..utils import get_url_from_template
+from virl2_client.utils import get_url_from_template
 
 if TYPE_CHECKING:
     import httpx

--- a/virl2_client/models/groups.py
+++ b/virl2_client/models/groups.py
@@ -19,7 +19,7 @@
 #
 import warnings
 
-from .group import *  # noqa
+from virl2_client.models.group import *  # noqa
 
 warnings.warn(
     "The module name 'virl2_client.models.groups' is deprecated. "

--- a/virl2_client/models/interface.py
+++ b/virl2_client/models/interface.py
@@ -23,14 +23,14 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from ..utils import check_stale, get_url_from_template, locked
-from ..utils import property_s as property
+from virl2_client.utils import check_stale, get_url_from_template, locked
+from virl2_client.utils import property_s as property
 
 if TYPE_CHECKING:
     import httpx
 
-    from .link import Link
-    from .node import Node
+    from virl2_client.models.link import Link
+    from virl2_client.models.node import Node
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/virl2_client/models/lab.py
+++ b/virl2_client/models/lab.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING, Any
 
 from httpx import HTTPStatusError
 
-from ..exceptions import (
+from virl2_client.exceptions import (
     AnnotationNotFound,
     ElementAlreadyExists,
     InterfaceNotFound,
@@ -40,26 +40,32 @@ from ..exceptions import (
     SmartAnnotationNotFound,
     VirlException,
 )
-from ..utils import UNCHANGED, _Sentinel, check_stale, get_url_from_template, locked
-from ..utils import property_s as property
-from .annotation import (
+from virl2_client.models.annotation import (
     Annotation,
     AnnotationEllipse,
     AnnotationLine,
     AnnotationRectangle,
     AnnotationText,
 )
-from .cl_pyats import ClPyats
-from .interface import Interface
-from .link import Link
-from .node import Node
-from .smart_annotation import SmartAnnotation
+from virl2_client.models.cl_pyats import ClPyats
+from virl2_client.models.interface import Interface
+from virl2_client.models.link import Link
+from virl2_client.models.node import Node
+from virl2_client.models.smart_annotation import SmartAnnotation
+from virl2_client.utils import (
+    UNCHANGED,
+    _Sentinel,
+    check_stale,
+    get_url_from_template,
+    locked,
+)
+from virl2_client.utils import property_s as property
 
 if TYPE_CHECKING:
     import httpx
 
-    from .annotation import AnnotationType
-    from .resource_pool import ResourcePool, ResourcePoolManagement
+    from virl2_client.models.annotation import AnnotationType
+    from virl2_client.models.resource_pool import ResourcePool, ResourcePoolManagement
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/virl2_client/models/lab_repository.py
+++ b/virl2_client/models/lab_repository.py
@@ -26,11 +26,11 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 
-from ..exceptions import LabRepositoryNotFound
-from ..utils import get_url_from_template
+from virl2_client.exceptions import LabRepositoryNotFound
+from virl2_client.utils import get_url_from_template
 
 if TYPE_CHECKING:
-    from .system import SystemManagement
+    from virl2_client.models.system import SystemManagement
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/virl2_client/models/licensing.py
+++ b/virl2_client/models/licensing.py
@@ -25,7 +25,7 @@ import time
 import warnings
 from typing import TYPE_CHECKING, Any
 
-from ..utils import get_url_from_template
+from virl2_client.utils import get_url_from_template
 
 if TYPE_CHECKING:
     import httpx

--- a/virl2_client/models/link.py
+++ b/virl2_client/models/link.py
@@ -24,15 +24,21 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any
 
-from ..utils import UNCHANGED, _Sentinel, check_stale, get_url_from_template, locked
-from ..utils import property_s as property
+from virl2_client.utils import (
+    UNCHANGED,
+    _Sentinel,
+    check_stale,
+    get_url_from_template,
+    locked,
+)
+from virl2_client.utils import property_s as property
 
 if TYPE_CHECKING:
     import httpx
 
-    from .interface import Interface
-    from .lab import Lab
-    from .node import Node
+    from virl2_client.models.interface import Interface
+    from virl2_client.models.lab import Lab
+    from virl2_client.models.node import Node
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/virl2_client/models/node.py
+++ b/virl2_client/models/node.py
@@ -28,21 +28,21 @@ from typing import TYPE_CHECKING, Any
 
 import httpx
 
-from ..exceptions import InterfaceNotFound, SmartAnnotationNotFound
-from ..utils import (
+from virl2_client.exceptions import InterfaceNotFound, SmartAnnotationNotFound
+from virl2_client.utils import (
     UNCHANGED,
     _Sentinel,
     check_stale,
     get_url_from_template,
     locked,
 )
-from ..utils import property_s as property
+from virl2_client.utils import property_s as property
 
 if TYPE_CHECKING:
-    from .interface import Interface
-    from .lab import Lab
-    from .link import Link
-    from .smart_annotation import SmartAnnotation
+    from virl2_client.models.interface import Interface
+    from virl2_client.models.lab import Lab
+    from virl2_client.models.link import Link
+    from virl2_client.models.smart_annotation import SmartAnnotation
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/virl2_client/models/node_image_definition.py
+++ b/virl2_client/models/node_image_definition.py
@@ -26,8 +26,8 @@ import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, BinaryIO
 
-from ..exceptions import InvalidContentType, InvalidImageFile
-from ..utils import get_url_from_template
+from virl2_client.exceptions import InvalidContentType, InvalidImageFile
+from virl2_client.utils import get_url_from_template
 
 if TYPE_CHECKING:
     import httpx

--- a/virl2_client/models/node_image_definitions.py
+++ b/virl2_client/models/node_image_definitions.py
@@ -19,7 +19,7 @@
 #
 import warnings
 
-from .node_image_definition import *  # noqa
+from virl2_client.models.node_image_definition import *  # noqa
 
 warnings.warn(
     "The module name 'virl2_client.models.node_image_definitions' is deprecated. "

--- a/virl2_client/models/resource_pool.py
+++ b/virl2_client/models/resource_pool.py
@@ -26,8 +26,8 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from ..exceptions import InvalidProperty
-from ..utils import get_url_from_template
+from virl2_client.exceptions import InvalidProperty
+from virl2_client.utils import get_url_from_template
 
 if TYPE_CHECKING:
     import httpx

--- a/virl2_client/models/resource_pools.py
+++ b/virl2_client/models/resource_pools.py
@@ -19,7 +19,7 @@
 #
 import warnings
 
-from .resource_pool import *  # noqa
+from virl2_client.models.resource_pool import *  # noqa
 
 warnings.warn(
     "The module name 'virl2_client.models.resource_pools' is deprecated. "

--- a/virl2_client/models/smart_annotation.py
+++ b/virl2_client/models/smart_annotation.py
@@ -23,14 +23,14 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from ..exceptions import InvalidProperty
-from ..utils import check_stale, get_url_from_template, locked
-from ..utils import property_s as property
+from virl2_client.exceptions import InvalidProperty
+from virl2_client.utils import check_stale, get_url_from_template, locked
+from virl2_client.utils import property_s as property
 
 if TYPE_CHECKING:
     import httpx
 
-    from .lab import Lab
+    from virl2_client.models.lab import Lab
 
 _LOGGER = logging.getLogger(__name__)
 _SMART_ANNOTATION_DEFAULTS = {

--- a/virl2_client/models/system.py
+++ b/virl2_client/models/system.py
@@ -25,8 +25,7 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from virl2_client.exceptions import ControllerNotFound
-
-from ..utils import OptInStatus, get_url_from_template
+from virl2_client.utils import OptInStatus, get_url_from_template
 
 if TYPE_CHECKING:
     import httpx

--- a/virl2_client/models/user.py
+++ b/virl2_client/models/user.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import warnings
 from typing import TYPE_CHECKING, Any
 
-from ..utils import UNCHANGED, OptInStatus, _Sentinel, get_url_from_template
+from virl2_client.utils import UNCHANGED, OptInStatus, _Sentinel, get_url_from_template
 
 if TYPE_CHECKING:
     import httpx

--- a/virl2_client/models/users.py
+++ b/virl2_client/models/users.py
@@ -19,7 +19,7 @@
 #
 import warnings
 
-from .user import *  # noqa
+from virl2_client.models.user import *  # noqa
 
 warnings.warn(
     "The module name 'virl2_client.models.users' is deprecated. "

--- a/virl2_client/utils.py
+++ b/virl2_client/utils.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING, Any, Type, TypeVar, cast
 
 import httpx
 
-from .exceptions import (
+from virl2_client.exceptions import (
     AnnotationNotFound,
     ElementNotFound,
     InterfaceNotFound,
@@ -41,7 +41,14 @@ from .exceptions import (
 )
 
 if TYPE_CHECKING:
-    from .models import Annotation, Interface, Lab, Link, Node, SmartAnnotation
+    from virl2_client.models import (
+        Annotation,
+        Interface,
+        Lab,
+        Link,
+        Node,
+        SmartAnnotation,
+    )
 
     Element = Lab | Node | Interface | Link | Annotation | SmartAnnotation
 

--- a/virl2_client/virl2_client.py
+++ b/virl2_client/virl2_client.py
@@ -36,8 +36,8 @@ from urllib.parse import urljoin, urlsplit, urlunsplit
 
 import httpx
 
-from .exceptions import InitializationError, LabNotFound
-from .models import (
+from virl2_client.exceptions import InitializationError, LabNotFound
+from virl2_client.models import (
     AuthManagement,
     GroupManagement,
     Lab,
@@ -48,8 +48,8 @@ from .models import (
     TokenAuth,
     UserManagement,
 )
-from .models.authentication import make_session
-from .utils import get_url_from_template, locked
+from virl2_client.models.authentication import make_session
+from virl2_client.utils import get_url_from_template, locked
 
 _LOGGER = logging.getLogger(__name__)
 cached = lru_cache(maxsize=None)  # cache results forever
@@ -590,12 +590,14 @@ class ClientLibrary:
         To replace the default event handling mechanism,
         subclass EventHandler (or EventHandlerBase if necessary),
         then do::
-            from .event_listening import EventListener
+            from virl2_client.event_listening import EventListener
             custom_listener = EventListener()
             custom_listener._event_handler = CustomHandler(client_library)
             client_library.event_listener = custom_listener
+
+        :returns:
         """
-        from .event_listening import EventListener
+        from virl2_client.event_listening import EventListener
 
         if self.event_listener is None:
             self.event_listener = EventListener(self)


### PR DESCRIPTION
Replace all relative imports (from . / from ..) with absolute imports (from virl2_client.) across the non-test codebase for consistency.