### PR TITLE
Add backward compatibility guards and tests for virl2_client 2.10

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,6 +114,13 @@ def client_library_server_2_19_0() -> Iterator[MagicMock]:
 
 
 @pytest.fixture
+def client_library_server_2_8_0() -> Iterator[MagicMock]:
+    """Simulate a controller running CML version 2.8.0."""
+
+    yield from client_library_patched_system_info(version="2.8.0")
+
+
+@pytest.fixture
 def client_library_server_2_9_0() -> Iterator[MagicMock]:
     """Simulate a controller running CML version 2.9.0.
 

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -1,0 +1,443 @@
+#
+# This file is part of VIRL 2
+# Copyright (c) 2019-2026, Cisco Systems, Inc.
+# All rights reserved.
+#
+# Python bindings for the Cisco VIRL 2 Network Simulation Platform
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Public API contract tests.
+
+These tests verify that the client library's public API surface remains
+backward-compatible. They run without a live server and catch accidental
+removals of classes, methods, or changes to method signatures that would
+break user code written against v2.8 or v2.9.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Top-level package exports
+# ---------------------------------------------------------------------------
+
+TOP_LEVEL_EXPORTS = [
+    "ClientConfig",
+    "ClientLibrary",
+    "InitializationError",
+    "InterfaceNotFound",
+    "LabNotFound",
+    "LinkNotFound",
+    "NodeNotFound",
+]
+
+
+@pytest.mark.parametrize("name", TOP_LEVEL_EXPORTS)
+def test_top_level_exports(name):
+    """All expected names are importable from virl2_client."""
+    import virl2_client
+
+    assert hasattr(virl2_client, name), f"virl2_client.{name} missing"
+
+
+def test_top_level_all_matches():
+    """__all__ contains at least the expected exports."""
+    import virl2_client
+
+    for name in TOP_LEVEL_EXPORTS:
+        assert name in virl2_client.__all__
+
+
+# ---------------------------------------------------------------------------
+# Models sub-package exports
+# ---------------------------------------------------------------------------
+
+MODEL_EXPORTS = [
+    "Annotation",
+    "AuthManagement",
+    "GroupManagement",
+    "Interface",
+    "Lab",
+    "LabRepository",
+    "LabRepositoryManagement",
+    "Licensing",
+    "Link",
+    "Node",
+    "NodeImageDefinitions",
+    "ResourcePoolManagement",
+    "SmartAnnotation",
+    "SystemManagement",
+    "TokenAuth",
+    "UserManagement",
+]
+
+
+@pytest.mark.parametrize("name", MODEL_EXPORTS)
+def test_model_exports(name):
+    """All expected model classes are importable from virl2_client.models."""
+    from virl2_client import models
+
+    assert hasattr(models, name), f"virl2_client.models.{name} missing"
+
+
+def test_model_all_matches():
+    """models.__all__ contains at least the expected exports."""
+    from virl2_client import models
+
+    for name in MODEL_EXPORTS:
+        assert name in models.__all__
+
+
+# ---------------------------------------------------------------------------
+# Exception hierarchy
+# ---------------------------------------------------------------------------
+
+
+def test_exception_hierarchy_element_not_found():
+    """ElementNotFound is a subclass of both VirlException and KeyError."""
+    from virl2_client.exceptions import ElementNotFound, VirlException
+
+    assert issubclass(ElementNotFound, VirlException)
+    assert issubclass(ElementNotFound, KeyError)
+
+
+def test_exception_hierarchy_specific_not_found():
+    """Each model-specific NotFound inherits from ElementNotFound."""
+    from virl2_client.exceptions import (
+        AnnotationNotFound,
+        ElementNotFound,
+        InterfaceNotFound,
+        LabNotFound,
+        LinkNotFound,
+        NodeNotFound,
+        SmartAnnotationNotFound,
+    )
+
+    for exc_cls in (
+        LabNotFound,
+        NodeNotFound,
+        InterfaceNotFound,
+        LinkNotFound,
+        AnnotationNotFound,
+        SmartAnnotationNotFound,
+    ):
+        assert issubclass(exc_cls, ElementNotFound), f"{exc_cls.__name__} hierarchy"
+
+
+def test_exception_hierarchy_element_already_exists():
+    """ElementAlreadyExists is a subclass of both VirlException and FileExistsError."""
+    from virl2_client.exceptions import ElementAlreadyExists, VirlException
+
+    assert issubclass(ElementAlreadyExists, VirlException)
+    assert issubclass(ElementAlreadyExists, FileExistsError)
+
+
+def test_exception_hierarchy_api_error():
+    """APIError inherits from both VirlException and httpx.HTTPStatusError."""
+    import httpx
+
+    from virl2_client.exceptions import APIError, VirlException
+
+    assert issubclass(APIError, VirlException)
+    assert issubclass(APIError, httpx.HTTPStatusError)
+
+
+def test_exception_hierarchy_feature_not_supported():
+    """FeatureNotSupported inherits from VirlException."""
+    from virl2_client.exceptions import FeatureNotSupported, VirlException
+
+    assert issubclass(FeatureNotSupported, VirlException)
+
+
+# ---------------------------------------------------------------------------
+# Method signature stability
+#
+# These tests verify that key methods retain their expected parameters.
+# New parameters may be added, but existing ones must not be removed.
+# ---------------------------------------------------------------------------
+
+# Format: ("module_path", "class.method", [required_params])
+# "self" is included to verify it's a regular method (not static/class).
+EXPECTED_SIGNATURES = [
+    (
+        "virl2_client.virl2_client",
+        "ClientLibrary.__init__",
+        ["self", "url", "username", "password", "ssl_verify"],
+    ),
+    (
+        "virl2_client.virl2_client",
+        "ClientLibrary.is_system_ready",
+        ["self", "wait"],
+    ),
+    (
+        "virl2_client.virl2_client",
+        "ClientLibrary.import_lab",
+        ["self", "topology", "title"],
+    ),
+    (
+        "virl2_client.virl2_client",
+        "ClientLibrary.all_labs",
+        ["self", "show_all"],
+    ),
+    (
+        "virl2_client.virl2_client",
+        "ClientLibrary.find_labs_by_title",
+        ["self", "title"],
+    ),
+    (
+        "virl2_client.virl2_client",
+        "ClientLibrary.create_lab",
+        ["self", "title"],
+    ),
+    (
+        "virl2_client.virl2_client",
+        "ClientLibrary.join_existing_lab",
+        ["self", "lab_id"],
+    ),
+    (
+        "virl2_client.virl2_client",
+        "ClientLibrary.get_diagnostics",
+        ["self"],
+    ),
+    (
+        "virl2_client.models.lab",
+        "Lab.start",
+        ["self", "wait"],
+    ),
+    (
+        "virl2_client.models.lab",
+        "Lab.stop",
+        ["self", "wait"],
+    ),
+    (
+        "virl2_client.models.lab",
+        "Lab.wipe",
+        ["self", "wait"],
+    ),
+    (
+        "virl2_client.models.lab",
+        "Lab.remove",
+        ["self"],
+    ),
+    (
+        "virl2_client.models.lab",
+        "Lab.create_node",
+        ["self", "label", "node_definition"],
+    ),
+    (
+        "virl2_client.models.lab",
+        "Lab.connect_two_nodes",
+        ["self", "node1", "node2"],
+    ),
+    (
+        "virl2_client.models.lab",
+        "Lab.create_link",
+        ["self", "i1", "i2"],
+    ),
+    (
+        "virl2_client.models.lab",
+        "Lab.sync",
+        ["self", "topology_only"],
+    ),
+    (
+        "virl2_client.models.lab",
+        "Lab.download",
+        ["self"],
+    ),
+    (
+        "virl2_client.models.node",
+        "Node.start",
+        ["self", "wait"],
+    ),
+    (
+        "virl2_client.models.node",
+        "Node.stop",
+        ["self", "wait"],
+    ),
+    (
+        "virl2_client.models.node",
+        "Node.create_interface",
+        ["self"],
+    ),
+    (
+        "virl2_client.models.node",
+        "Node.add_tag",
+        ["self", "tag"],
+    ),
+    (
+        "virl2_client.models.node",
+        "Node.remove_tag",
+        ["self", "tag"],
+    ),
+    (
+        "virl2_client.models.node",
+        "Node.clone_image",
+        ["self"],
+    ),
+    (
+        "virl2_client.models.system",
+        "SystemManagement.sync_compute_hosts",
+        ["self"],
+    ),
+    (
+        "virl2_client.models.system",
+        "SystemManagement.sync_system_notices",
+        ["self"],
+    ),
+    (
+        "virl2_client.models.auth_management",
+        "AuthManagement.sync_if_outdated",
+        ["self"],
+    ),
+    (
+        "virl2_client.models.lab_repository",
+        "LabRepositoryManagement.sync_lab_repositories",
+        ["self"],
+    ),
+    (
+        "virl2_client.models.lab_repository",
+        "LabRepositoryManagement.add_lab_repository",
+        ["self", "url", "name", "folder"],
+    ),
+]
+
+
+def _resolve_method(module_path, class_method):
+    """Import and resolve a 'Class.method' string to the actual callable."""
+    import importlib
+
+    cls_name, method_name = class_method.split(".")
+    mod = importlib.import_module(module_path)
+    cls = getattr(mod, cls_name)
+    return getattr(cls, method_name)
+
+
+@pytest.mark.parametrize(
+    "module_path,class_method,required_params",
+    EXPECTED_SIGNATURES,
+    ids=[f"{m}.{cm}" for m, cm, _ in EXPECTED_SIGNATURES],
+)
+def test_method_signatures(module_path, class_method, required_params):
+    """Critical method signatures retain their expected parameters."""
+    method = _resolve_method(module_path, class_method)
+    func = method
+    if isinstance(method, property):
+        func = method.fget
+    while hasattr(func, "__wrapped__"):
+        func = func.__wrapped__
+    sig = inspect.signature(func)
+    actual_params = list(sig.parameters.keys())
+    for param in required_params:
+        assert param in actual_params, (
+            f"{module_path}.{class_method} missing parameter '{param}'; "
+            f"actual params: {actual_params}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# URL template stability
+#
+# The client's _URL_TEMPLATES dict defines the REST endpoints it depends on.
+# Removing a key would silently break any code path that calls _url_for()
+# with that endpoint name.
+# ---------------------------------------------------------------------------
+
+CLIENT_LIBRARY_URL_TEMPLATES = [
+    "auth",
+    "old_auth",
+    "system_info",
+    "import",
+    "import_1x",
+    "sample_labs",
+    "labs",
+    "lab",
+    "lab_topology",
+    "diagnostics",
+    "system_health",
+    "system_stats",
+    "populate_lab_tiles",
+]
+
+LAB_URL_TEMPLATES = [
+    "lab",
+    "nodes",
+    "links",
+    "interfaces",
+    "start",
+    "stop",
+    "state",
+    "wipe",
+    "events",
+    "topology",
+    "download",
+    "associations",
+    "connector_mappings",
+    "resource_pools",
+    "annotations",
+]
+
+NODE_URL_TEMPLATES = [
+    "node",
+    "state",
+    "start",
+    "stop",
+    "wipe_disks",
+    "clone_image",
+    "extract_configuration",
+    "console_log",
+    "console_key",
+    "vnc_key",
+    "layer3_addresses",
+]
+
+
+@pytest.mark.parametrize("key", CLIENT_LIBRARY_URL_TEMPLATES)
+def test_client_library_url_templates(key):
+    """ClientLibrary._URL_TEMPLATES contains all expected keys."""
+    from virl2_client.virl2_client import ClientLibrary
+
+    assert key in ClientLibrary._URL_TEMPLATES
+
+
+@pytest.mark.parametrize("key", LAB_URL_TEMPLATES)
+def test_lab_url_templates(key):
+    """Lab._URL_TEMPLATES contains all expected keys."""
+    from virl2_client.models.lab import Lab
+
+    assert key in Lab._URL_TEMPLATES
+
+
+@pytest.mark.parametrize("key", NODE_URL_TEMPLATES)
+def test_node_url_templates(key):
+    """Node._URL_TEMPLATES contains all expected keys."""
+    from virl2_client.models.node import Node
+
+    assert key in Node._URL_TEMPLATES
+
+
+# ---------------------------------------------------------------------------
+# New in 2.10: Version importable from utils
+# ---------------------------------------------------------------------------
+
+
+def test_version_importable_from_utils():
+    """Version class is importable from virl2_client.utils."""
+    from virl2_client.utils import Version
+
+    v = Version("2.10.0")
+    assert v.major == 2 and v.minor == 10 and v.patch == 0

--- a/tests/test_backward_compat.py
+++ b/tests/test_backward_compat.py
@@ -1,0 +1,513 @@
+#
+# This file is part of VIRL 2
+# Copyright (c) 2019-2026, Cisco Systems, Inc.
+# All rights reserved.
+#
+# Python bindings for the Cisco VIRL 2 Network Simulation Platform
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Backward compatibility tests for virl2_client 2.10.
+
+These tests verify that the v2.10 client works correctly against older
+CML servers (2.8, 2.9) by mocking server responses with ``respx``.
+
+Tests cover:
+- Auth flow branching (authok vs authentication endpoint)
+- Version guard enforcement for new-in-2.9+ features
+- Graceful handling of 404s for endpoints missing on older servers
+- Old response shape tolerance (ComputeHost with nodes list, etc.)
+- Diagnostics endpoint compatibility
+- Controller version property availability
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, Mock, patch
+
+import httpx
+import pytest
+import respx
+
+from virl2_client.exceptions import APIError, FeatureNotSupported
+from virl2_client.models import Lab
+from virl2_client.models.authentication import CustomClient
+from virl2_client.models.lab_repository import LabRepositoryManagement
+from virl2_client.models.resource_pool import ResourcePoolManagement
+from virl2_client.models.system import ComputeHost, SystemManagement
+from virl2_client.models.user import UserManagement
+from virl2_client.virl2_client import ClientLibrary, Version
+
+FAKE_HOST = "https://0.0.0.0"
+FAKE_HOST_API = f"{FAKE_HOST}/api/v0/"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_client(respx_mock, version: str) -> ClientLibrary:
+    """Create a ClientLibrary connected to a fake server reporting *version*."""
+    respx_mock.get(FAKE_HOST_API + "system_information").respond(
+        json={"version": version, "ready": True},
+    )
+    respx_mock.post(FAKE_HOST_API + "authenticate").respond(json="BOGUS_TOKEN")
+    if Version(version) >= Version("2.10.0"):
+        respx_mock.get(FAKE_HOST_API + "authentication").respond(
+            json={
+                "username": "admin",
+                "id": "00000000-0000-4000-a000-000000000000",
+                "token": "BOGUS_TOKEN",
+                "admin": True,
+            }
+        )
+    else:
+        respx_mock.get(FAKE_HOST_API + "authok").respond(text="OK")
+    return ClientLibrary(
+        url=FAKE_HOST,
+        username="test",
+        password="pa$$",
+        check_version=False,
+    )
+
+
+def _make_lab(client: ClientLibrary, lab_id: str = "lab-id") -> Lab:
+    """Create a Lab wired to *client* with mock dependencies."""
+    rpm = ResourcePoolManagement(client._session, auto_sync=False)
+    um = UserManagement(client._session, auto_sync=False)
+    return Lab(
+        "test",
+        lab_id,
+        client._session,
+        "u",
+        "p",
+        auto_sync=False,
+        resource_pool_manager=rpm,
+        user_management=um,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Controller version property
+# ---------------------------------------------------------------------------
+
+
+class TestControllerVersionOnSession:
+    """Verify that controller_version is stored on the session."""
+
+    @respx.mock
+    def test_version_stored_for_2_10(self):
+        client = _make_client(respx.mock, "2.10.0")
+        assert client._session.controller_version == Version("2.10.0")
+
+    @respx.mock
+    def test_version_stored_for_2_9(self):
+        client = _make_client(respx.mock, "2.9.0")
+        assert client._session.controller_version == Version("2.9.0")
+
+    @respx.mock
+    def test_version_stored_for_2_8(self):
+        client = _make_client(respx.mock, "2.8.0")
+        assert client._session.controller_version == Version("2.8.0")
+
+
+# ---------------------------------------------------------------------------
+# Auth flow branching
+# ---------------------------------------------------------------------------
+
+
+class TestAuthFlowBranching:
+    """Verify that the correct auth endpoint is used based on server version."""
+
+    @respx.mock
+    def test_2_10_uses_authentication_endpoint(self):
+        """CML 2.10 should GET /authentication and extract user info."""
+        auth_route = respx.get(FAKE_HOST_API + "authentication").respond(
+            json={
+                "username": "admin",
+                "id": "00000000-0000-4000-a000-000000000000",
+                "token": "T",
+                "admin": True,
+            }
+        )
+        respx.get(FAKE_HOST_API + "system_information").respond(
+            json={"version": "2.10.0", "ready": True},
+        )
+        respx.post(FAKE_HOST_API + "authenticate").respond(json="T")
+
+        client = ClientLibrary(url=FAKE_HOST, username="test", password="pa$$")
+        assert auth_route.called
+        assert client.username == "admin"
+        assert client.admin is True
+
+    @respx.mock
+    def test_2_9_uses_authok_endpoint(self):
+        """CML 2.9 should GET /authok (legacy path)."""
+        authok_route = respx.get(FAKE_HOST_API + "authok").respond(text="OK")
+        respx.get(FAKE_HOST_API + "system_information").respond(
+            json={"version": "2.9.0", "ready": True},
+        )
+        respx.post(FAKE_HOST_API + "authenticate").respond(json="T")
+
+        ClientLibrary(url=FAKE_HOST, username="test", password="pa$$")
+        assert authok_route.called
+
+    @respx.mock
+    def test_2_8_uses_authok_endpoint(self):
+        """CML 2.8 should GET /authok (legacy path)."""
+        authok_route = respx.get(FAKE_HOST_API + "authok").respond(text="OK")
+        respx.get(FAKE_HOST_API + "system_information").respond(
+            json={"version": "2.8.0", "ready": True},
+        )
+        respx.post(FAKE_HOST_API + "authenticate").respond(json="T")
+
+        ClientLibrary(
+            url=FAKE_HOST,
+            username="test",
+            password="pa$$",
+            check_version=False,
+        )
+        assert authok_route.called
+
+    @respx.mock
+    def test_unparseable_version_raises(self):
+        """If the controller returns a garbled version, raise InitializationError."""
+        from virl2_client.virl2_client import InitializationError
+
+        respx.get(FAKE_HOST_API + "system_information").respond(
+            json={"version": "not-a-version", "ready": True},
+        )
+        respx.post(FAKE_HOST_API + "authenticate").respond(json="T")
+
+        with pytest.raises(InitializationError, match="invalid version"):
+            ClientLibrary(url=FAKE_HOST, username="test", password="pa$$")
+
+
+# ---------------------------------------------------------------------------
+# Version guard enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestVersionGuardCloneImage:
+    """Node.clone_image() requires CML >= 2.9."""
+
+    @respx.mock
+    def test_clone_image_blocked_on_2_8(self):
+        """clone_image() raises FeatureNotSupported against a 2.8 server."""
+        client = _make_client(respx.mock, "2.8.0")
+        lab = _make_lab(client)
+        from virl2_client.models.node import Node
+
+        node = Node(lab, "n1", "mynode", "alpine")
+        with pytest.raises(FeatureNotSupported, match="2.9.0"):
+            node.clone_image()
+
+    @respx.mock
+    def test_clone_image_allowed_on_2_9(self):
+        """clone_image() proceeds on a 2.9 server (HTTP call is made)."""
+        client = _make_client(respx.mock, "2.9.0")
+        lab = _make_lab(client)
+        from virl2_client.models.node import Node
+
+        node = Node(lab, "n1", "mynode", "alpine")
+        respx.put(FAKE_HOST_API + "labs/lab-id/nodes/n1/clone_image").respond(
+            json={"image_id": "new-image"}
+        )
+        result = node.clone_image()
+        assert result == {"image_id": "new-image"}
+
+    @respx.mock
+    def test_clone_image_allowed_on_2_10(self):
+        """clone_image() proceeds on a 2.10 server."""
+        client = _make_client(respx.mock, "2.10.0")
+        lab = _make_lab(client)
+        from virl2_client.models.node import Node
+
+        node = Node(lab, "n1", "mynode", "alpine")
+        respx.put(FAKE_HOST_API + "labs/lab-id/nodes/n1/clone_image").respond(
+            json={"image_id": "img-123"}
+        )
+        result = node.clone_image()
+        assert result == {"image_id": "img-123"}
+
+
+class TestVersionGuardLabRepositories:
+    """LabRepositoryManagement methods require CML >= 2.9."""
+
+    @respx.mock
+    def test_sync_lab_repos_blocked_on_2_8(self):
+        client = _make_client(respx.mock, "2.8.0")
+        system = SystemManagement(client._session, auto_sync=False)
+        mgmt = LabRepositoryManagement(system, client._session, auto_sync=False)
+        with pytest.raises(FeatureNotSupported, match="2.9.0"):
+            mgmt.sync_lab_repositories()
+
+    @respx.mock
+    def test_get_lab_repos_blocked_on_2_8(self):
+        client = _make_client(respx.mock, "2.8.0")
+        system = SystemManagement(client._session, auto_sync=False)
+        mgmt = LabRepositoryManagement(system, client._session, auto_sync=False)
+        with pytest.raises(FeatureNotSupported, match="2.9.0"):
+            mgmt.get_lab_repositories()
+
+    @respx.mock
+    def test_add_lab_repo_blocked_on_2_8(self):
+        client = _make_client(respx.mock, "2.8.0")
+        system = SystemManagement(client._session, auto_sync=False)
+        mgmt = LabRepositoryManagement(system, client._session, auto_sync=False)
+        with pytest.raises(FeatureNotSupported, match="2.9.0"):
+            mgmt.add_lab_repository("https://example.com/repo.git", "test", "folder")
+
+    @respx.mock
+    def test_refresh_lab_repos_blocked_on_2_8(self):
+        client = _make_client(respx.mock, "2.8.0")
+        system = SystemManagement(client._session, auto_sync=False)
+        mgmt = LabRepositoryManagement(system, client._session, auto_sync=False)
+        with pytest.raises(FeatureNotSupported, match="2.9.0"):
+            mgmt.refresh_lab_repositories()
+
+    @respx.mock
+    def test_sync_lab_repos_allowed_on_2_9(self):
+        client = _make_client(respx.mock, "2.9.0")
+        system = SystemManagement(client._session, auto_sync=False)
+        mgmt = LabRepositoryManagement(system, client._session, auto_sync=False)
+        respx.get(FAKE_HOST_API + "lab_repos").respond(json=[])
+        mgmt.sync_lab_repositories()
+
+
+# ---------------------------------------------------------------------------
+# ComputeHost response shape tolerance
+# ---------------------------------------------------------------------------
+
+
+class TestComputeHostResponseShapes:
+    """sync_compute_hosts handles both old (with nodes list) and new (with
+    node_counts) response shapes."""
+
+    @respx.mock
+    def test_v2_8_response_with_nodes_list(self):
+        """v2.8 includes a 'nodes' list and no 'node_counts'."""
+        client = _make_client(respx.mock, "2.8.0")
+        system = SystemManagement(client._session, auto_sync=False)
+        respx.get(FAKE_HOST_API + "system/compute_hosts").respond(
+            json=[
+                {
+                    "id": "compute-1",
+                    "hostname": "host1",
+                    "server_address": "10.0.0.1",
+                    "is_connector": False,
+                    "is_simulator": True,
+                    "is_connected": True,
+                    "is_synced": True,
+                    "admission_state": "ADMITTED",
+                    "nodes": ["node-a", "node-b"],
+                }
+            ]
+        )
+        system.sync_compute_hosts()
+        assert "compute-1" in system._compute_hosts
+        host = system._compute_hosts["compute-1"]
+        assert host._node_counts == {}
+
+    @respx.mock
+    def test_v2_10_response_with_node_counts(self):
+        """v2.10 includes 'node_counts' and no 'nodes'."""
+        client = _make_client(respx.mock, "2.10.0")
+        system = SystemManagement(client._session, auto_sync=False)
+        respx.get(FAKE_HOST_API + "system/compute_hosts").respond(
+            json=[
+                {
+                    "id": "compute-2",
+                    "hostname": "host2",
+                    "server_address": "10.0.0.2",
+                    "is_connector": False,
+                    "is_simulator": True,
+                    "is_connected": True,
+                    "is_synced": True,
+                    "admission_state": "ADMITTED",
+                    "node_counts": {"deployed": 5, "running": 3, "orphans": 0},
+                }
+            ]
+        )
+        system.sync_compute_hosts()
+        host = system._compute_hosts["compute-2"]
+        assert host._node_counts == {"deployed": 5, "running": 3, "orphans": 0}
+
+    @respx.mock
+    def test_v2_9_response_with_both_nodes_and_node_counts(self):
+        """v2.9 may include both fields; client should handle gracefully."""
+        client = _make_client(respx.mock, "2.9.0")
+        system = SystemManagement(client._session, auto_sync=False)
+        respx.get(FAKE_HOST_API + "system/compute_hosts").respond(
+            json=[
+                {
+                    "id": "compute-3",
+                    "hostname": "host3",
+                    "server_address": "10.0.0.3",
+                    "is_connector": False,
+                    "is_simulator": True,
+                    "is_connected": True,
+                    "is_synced": True,
+                    "admission_state": "ADMITTED",
+                    "nodes": ["node-x"],
+                    "node_counts": {"deployed": 1, "running": 1, "orphans": 0},
+                }
+            ]
+        )
+        system.sync_compute_hosts()
+        host = system._compute_hosts["compute-3"]
+        assert host._node_counts == {"deployed": 1, "running": 1, "orphans": 0}
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics endpoint compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnosticsCompat:
+    """get_diagnostics uses /diagnostics/{category} which exists on all versions."""
+
+    @respx.mock
+    def test_diagnostics_soft_fail_on_missing_category(self):
+        """If a category endpoint returns an error, diagnostics records it
+        rather than raising."""
+        client = _make_client(respx.mock, "2.8.0")
+        from virl2_client.virl2_client import DiagnosticsCategory
+
+        respx.get(FAKE_HOST_API + "diagnostics/computes").respond(
+            status_code=404,
+            json={"description": "Not Found"},
+        )
+        result = client.get_diagnostics(DiagnosticsCategory.COMPUTES)
+        assert "computes" in result
+        assert "error" in result["computes"]
+
+    @respx.mock
+    def test_diagnostics_success(self):
+        """Normal diagnostics fetch returns the data."""
+        client = _make_client(respx.mock, "2.10.0")
+        from virl2_client.virl2_client import DiagnosticsCategory
+
+        respx.get(FAKE_HOST_API + "diagnostics/labs").respond(json={"active_labs": 3})
+        result = client.get_diagnostics(DiagnosticsCategory.LABS)
+        assert result == {"labs": {"active_labs": 3}}
+
+
+# ---------------------------------------------------------------------------
+# Missing endpoint 404 handling (features that exist only on newer servers)
+# ---------------------------------------------------------------------------
+
+
+class TestMissingEndpoint404:
+    """When the client calls an endpoint that does not exist on the server,
+    the server returns 404 and the client should raise APIError."""
+
+    @respx.mock
+    def test_404_on_associations_raises_api_error(self):
+        """Lab associations endpoint missing on v2.8 gives a clean APIError."""
+        client = _make_client(respx.mock, "2.8.0")
+        lab = _make_lab(client)
+        respx.get(FAKE_HOST_API + "labs/lab-id/associations").respond(
+            status_code=404, json={"description": "Not Found"}
+        )
+
+        with pytest.raises(httpx.HTTPStatusError):
+            lab._session.get(lab._url_for("associations"))
+
+
+# ---------------------------------------------------------------------------
+# Version comparison edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestVersionComparison:
+    """Verify Version comparison used in auth branching and guards."""
+
+    def test_version_equality(self):
+        assert Version("2.10.0") == Version("2.10.0")
+
+    def test_version_less_than(self):
+        assert Version("2.8.0") < Version("2.9.0")
+        assert Version("2.9.0") < Version("2.10.0")
+
+    def test_version_greater_equal(self):
+        assert Version("2.10.0") >= Version("2.10.0")
+        assert Version("2.10.0") >= Version("2.9.0")
+
+    def test_version_with_patch(self):
+        assert Version("2.8.1") >= Version("2.8.0")
+        assert Version("2.8.1") < Version("2.9.0")
+
+    def test_version_hashable(self):
+        versions = {Version("2.8.0"), Version("2.9.0"), Version("2.8.0")}
+        assert len(versions) == 2
+
+
+# ---------------------------------------------------------------------------
+# Version enforcement (check_controller_version)
+# ---------------------------------------------------------------------------
+
+
+class TestVersionEnforcement:
+    """check_controller_version rejects controllers too old or too new."""
+
+    @respx.mock
+    def test_accepts_2_9_server(self):
+        """Client should accept a server within the 3-minor support window."""
+        client = _make_client(respx.mock, "2.9.0")
+        assert client._session.controller_version == Version("2.9.0")
+
+    @respx.mock
+    def test_accepts_2_10_server(self):
+        client = _make_client(respx.mock, "2.10.0")
+        assert client._session.controller_version == Version("2.10.0")
+
+    @respx.mock
+    def test_rejects_too_old_server(self):
+        """Client should reject a server outside the 3-minor support window."""
+        from virl2_client.virl2_client import ClientLibrary as CL
+        from virl2_client.virl2_client import InitializationError
+
+        too_old = str(CL.VERSION.minor - 3)
+        old_version = f"2.{too_old}.0"
+
+        respx.get(FAKE_HOST_API + "system_information").respond(
+            json={"version": old_version, "ready": True},
+        )
+        respx.post(FAKE_HOST_API + "authenticate").respond(json="T")
+
+        with pytest.raises(InitializationError, match="Unsupported minor version"):
+            ClientLibrary(url=FAKE_HOST, username="test", password="pa$$")
+
+
+# ---------------------------------------------------------------------------
+# Session carries controller version for models
+# ---------------------------------------------------------------------------
+
+
+class TestSessionControllerVersion:
+    """The session object carries controller_version so models can access it."""
+
+    @respx.mock
+    def test_session_has_version(self):
+        client = _make_client(respx.mock, "2.9.0")
+        assert client._session.controller_version == Version("2.9.0")
+
+    @respx.mock
+    def test_model_can_read_version_via_session(self):
+        client = _make_client(respx.mock, "2.8.0")
+        system = SystemManagement(client._session, auto_sync=False)
+        assert system._session.controller_version == Version("2.8.0")

--- a/tests/test_client_library.py
+++ b/tests/test_client_library.py
@@ -843,9 +843,11 @@ def test_check_version_skip_paths(
     cl = ClientLibrary(url=FAKE_URL, username="test", password="pa$$")
     cl.check_version = False
     with patch.object(cl, "system_info", return_value={"version": "2.0.0"}):
-        assert cl.check_controller_version() is None
+        result = cl.check_controller_version()
+        assert result == Version("2.0.0")
     with patch.object(cl, "system_info", return_value={"version": object()}):
-        assert cl.check_controller_version() is None
+        with pytest.raises(InitializationError, match="invalid version"):
+            cl.check_controller_version()
 
 
 def test_join_lab_propagates_error(

--- a/tests/test_client_library_runtime.py
+++ b/tests/test_client_library_runtime.py
@@ -368,24 +368,24 @@ def test_client_get_host_rt() -> None:
 
 
 def test_check_version_invalid_str_rt() -> None:
-    """check_controller_version returns None for invalid version string.
+    """check_controller_version raises InitializationError for invalid version string."""
+    from virl2_client.virl2_client import InitializationError
 
-    NOTE: LLM-generated test -- verify for correctness.
-    """
     client = _make_client()
     client._session.get.return_value.json.return_value = {"version": "not-a-version"}
-    assert client.check_controller_version() is None
+    with pytest.raises(InitializationError, match="invalid version"):
+        client.check_controller_version()
 
 
 def test_check_version_disabled_rt() -> None:
-    """check_controller_version skips when check_version=False.
+    """check_controller_version returns parsed Version when check_version=False."""
+    from virl2_client.utils import Version
 
-    NOTE: LLM-generated test -- verify for correctness.
-    """
     client = _make_client()
     client.check_version = False
     client._session.get.return_value.json.return_value = {"version": "2.10.0"}
-    assert client.check_controller_version() is None
+    result = client.check_controller_version()
+    assert result == Version("2.10.0")
 
 
 def test_check_version_major_mismatch_rt() -> None:

--- a/virl2_client/exceptions.py
+++ b/virl2_client/exceptions.py
@@ -153,3 +153,7 @@ class APIError(VirlException, httpx.HTTPStatusError):
     """Raised when the CML REST API returns an HTTP error response."""
 
     pass
+
+
+class FeatureNotSupported(VirlException):
+    pass

--- a/virl2_client/models/lab_repository.py
+++ b/virl2_client/models/lab_repository.py
@@ -27,7 +27,7 @@ from typing import TYPE_CHECKING, Any
 import httpx
 
 from ..exceptions import LabRepositoryNotFound
-from ..utils import get_url_from_template
+from ..utils import _requires_version, get_url_from_template
 
 if TYPE_CHECKING:
     from .system import SystemManagement
@@ -81,7 +81,7 @@ class LabRepository:
         return get_url_from_template(endpoint, self._URL_TEMPLATES, kwargs)
 
     @property
-    def id(self) -> str:  # noqa: A003
+    def id(self) -> str:
         """Return the ID of the lab repository.
 
         :returns: The unique repository identifier.
@@ -205,8 +205,12 @@ class LabRepositoryManagement:
         ):
             self.sync_lab_repositories()
 
+    @_requires_version("2.9.0")
     def sync_lab_repositories(self) -> None:
-        """Synchronize lab repositories from the server."""
+        """Synchronize lab repositories from the server.
+
+        Requires CML server >= 2.9.
+        """
         url = self._url_for("lab_repos")
         lab_repositories = self._session.get(url).json()
         lab_repository_ids = []
@@ -222,18 +226,24 @@ class LabRepositoryManagement:
                 self._lab_repositories.pop(repo_id)
         self._last_sync_lab_repository_time = time.time()
 
+    @_requires_version("2.9.0")
     def get_lab_repositories(self) -> list[dict[str, Any]]:
         """
         Get the list of configured lab repositories.
+
+        Requires CML server >= 2.9.
 
         :returns: A list of lab repository objects.
         """
         url = self._url_for("lab_repos")
         return self._session.get(url).json()
 
+    @_requires_version("2.9.0")
     def add_lab_repository(self, url: str, name: str, folder: str) -> dict[str, Any]:
         """
         Add a lab repository.
+
+        Requires CML server >= 2.9.
 
         :param url: The URL of the lab repository.
         :param name: The name of the lab repository.
@@ -247,9 +257,12 @@ class LabRepositoryManagement:
         self.add_lab_repository_local(**result)
         return result
 
+    @_requires_version("2.9.0")
     def refresh_lab_repositories(self) -> dict[str, dict[str, Any]]:
         """
         Performs a git pull on each configured lab repository and returns the result.
+
+        Requires CML server >= 2.9.
 
         :returns: A dictionary containing the refresh status for each repository.
         """

--- a/virl2_client/models/node.py
+++ b/virl2_client/models/node.py
@@ -31,6 +31,7 @@ import httpx
 from ..exceptions import InterfaceNotFound, SmartAnnotationNotFound
 from ..utils import (
     UNCHANGED,
+    _requires_version,
     _Sentinel,
     check_stale,
     get_url_from_template,
@@ -917,9 +918,12 @@ class Node:
             self.wait_until_converged()
 
     @check_stale
+    @_requires_version("2.9.0")
     def clone_image(self) -> dict[str, Any]:
         """
         Clone the node's disks into a new Image definition.
+
+        Requires CML server >= 2.9.
 
         :returns: The new image definition data from the server.
         """

--- a/virl2_client/models/system.py
+++ b/virl2_client/models/system.py
@@ -624,7 +624,7 @@ class SystemNotice:
     def __init__(
         self,
         system: SystemManagement,
-        id: str,
+        notice_id: str,
         level: str,
         label: str,
         content: str,
@@ -636,7 +636,7 @@ class SystemNotice:
         A system notice, which notifies users of maintenance or other events.
 
         :param system: The SystemManagement instance.
-        :param id: The ID of the system notice.
+        :param notice_id: The ID of the system notice.
         :param level: The level of the system notice.
         :param label: The label of the system notice.
         :param content: The content of the system notice.
@@ -646,7 +646,7 @@ class SystemNotice:
         """
         self._system = system
         self._session: httpx.Client = system._session
-        self._id = id
+        self._id = notice_id
         self._level = level
         self._label = label
         self._content = content

--- a/virl2_client/utils.py
+++ b/virl2_client/utils.py
@@ -20,18 +20,20 @@
 
 from __future__ import annotations
 
+import re
 import warnings
 from collections.abc import Callable
 from contextlib import nullcontext
 from enum import Enum
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Type, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 import httpx
 
 from .exceptions import (
     AnnotationNotFound,
     ElementNotFound,
+    FeatureNotSupported,
     InterfaceNotFound,
     LabNotFound,
     LinkNotFound,
@@ -46,6 +48,77 @@ if TYPE_CHECKING:
     Element = Lab | Node | Interface | Link | Annotation | SmartAnnotation
 
 TCallable = TypeVar("TCallable", bound=Callable)
+
+
+class Version:
+    __slots__ = ("major", "minor", "patch", "version_str")
+
+    def __init__(self, version_str: str) -> None:
+        self.version_str = version_str
+        version_tuple = self.parse_version_str(version_str)
+        self.major = int(version_tuple[0])
+        self.minor = int(version_tuple[1])
+        self.patch = int(version_tuple[2])
+
+    @staticmethod
+    def parse_version_str(version_str: str) -> str:
+        regex = r"^(\d+)\.(\d+)\.(\d+)(.*)$"
+        res = re.findall(regex, version_str)
+        if not res:
+            raise ValueError("Malformed version string.")
+        return res[0]
+
+    def __repr__(self):
+        return self.version_str
+
+    def _as_tuple(self) -> tuple[int, int, int]:
+        return (self.major, self.minor, self.patch)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Version):
+            return False
+        return self._as_tuple() == other._as_tuple()
+
+    def __gt__(self, other: object) -> bool:
+        if not isinstance(other, Version):
+            return False
+        return self._as_tuple() > other._as_tuple()
+
+    def __ge__(self, other: object) -> bool:
+        if not isinstance(other, Version):
+            return False
+        return self._as_tuple() >= other._as_tuple()
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, Version):
+            return False
+        return self._as_tuple() < other._as_tuple()
+
+    def __le__(self, other: object) -> bool:
+        if not isinstance(other, Version):
+            return False
+        return self._as_tuple() <= other._as_tuple()
+
+    def __hash__(self) -> int:
+        return hash(self._as_tuple())
+
+    def major_differs(self, other: Version) -> bool:
+        return self.major != other.major
+
+    def major_lt(self, other: Version) -> bool:
+        return self.major < other.major
+
+    def minor_differs(self, other: Version) -> bool:
+        return self.minor != other.minor
+
+    def minor_lt(self, other: Version) -> bool:
+        return self.minor < other.minor
+
+    def patch_differs(self, other: Version) -> bool:
+        return self.patch != other.patch
+
+    def minor_or_patch_differs(self, other: Version) -> bool:
+        return self.minor_differs(other) or self.patch_differs(other)
 
 
 class _Sentinel:
@@ -81,7 +154,7 @@ def _make_not_found(instance: Element) -> ElementNotFound:
     class_name = type(instance).__name__
     if class_name.startswith("Annotation"):
         class_name = "Annotation"
-    error: Type[ElementNotFound] = {
+    error: type[ElementNotFound] = {
         "Lab": LabNotFound,
         "Node": NodeNotFound,
         "Interface": InterfaceNotFound,
@@ -261,3 +334,28 @@ def _deprecated_argument(
             f"The argument '{argument_name}' is deprecated. Reason: {reason}",
             DeprecationWarning,
         )
+
+
+def _requires_version(min_version: str) -> Callable:
+    """Decorator that guards a method behind a minimum CML server version.
+
+    If the controller version is older than *min_version*, a
+    ``FeatureNotSupported`` error is raised with a user-friendly message
+    *before* the HTTP call is made.
+    """
+    min_ver = Version(min_version)
+
+    def decorator(func: TCallable) -> TCallable:
+        @wraps(func)
+        def wrapper(self, *args, **kwargs):
+            if self._session.controller_version < min_ver:
+                raise FeatureNotSupported(
+                    f"{type(self).__name__}.{func.__name__}() requires "
+                    f"CML server >= {min_version}, but the connected "
+                    f"controller is running {self._session.controller_version}."
+                )
+            return func(self, *args, **kwargs)
+
+        return cast(TCallable, wrapper)
+
+    return decorator

--- a/virl2_client/virl2_client.py
+++ b/virl2_client/virl2_client.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import getpass
 import logging
 import os
-import re
 import sys
 import time
 import warnings
@@ -49,86 +48,10 @@ from .models import (
     UserManagement,
 )
 from .models.authentication import make_session
-from .utils import get_url_from_template, locked
+from .utils import Version, get_url_from_template, locked
 
 _LOGGER = logging.getLogger(__name__)
 cached = lru_cache(maxsize=None)  # cache results forever
-
-
-class Version:
-    """Represents a semantic version string (major.minor.patch)."""
-
-    __slots__ = ("version_str", "major", "minor", "patch")
-
-    def __init__(self, version_str: str) -> None:
-        self.version_str = version_str
-        version_tuple = self.parse_version_str(version_str)
-        self.major = int(version_tuple[0])
-        self.minor = int(version_tuple[1])
-        self.patch = int(version_tuple[2])
-
-    @staticmethod
-    def parse_version_str(version_str: str) -> tuple[str, str, str, str]:
-        """Parse a version string into its components.
-
-        :param version_str: A version string in the form major.minor.patch[extra].
-        :returns: A 4-tuple of (major, minor, patch, extra) as strings.
-        :raises ValueError: If the version string does not match the expected format.
-        """
-        regex = r"^(\d+)\.(\d+)\.(\d+)(.*)$"
-        res = re.findall(regex, version_str)
-        if not res:
-            raise ValueError("Malformed version string.")
-        return res[0]
-
-    def __repr__(self) -> str:
-        return self.version_str
-
-    def _as_tuple(self) -> tuple[int, int, int]:
-        return (self.major, self.minor, self.patch)
-
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, Version):
-            return False
-        return self._as_tuple() == other._as_tuple()
-
-    def __gt__(self, other: object) -> bool:
-        if not isinstance(other, Version):
-            return False
-        return self._as_tuple() > other._as_tuple()
-
-    def __ge__(self, other: object) -> bool:
-        if not isinstance(other, Version):
-            return False
-        return self._as_tuple() >= other._as_tuple()
-
-    def __lt__(self, other: object) -> bool:
-        if not isinstance(other, Version):
-            return False
-        return self._as_tuple() < other._as_tuple()
-
-    def __le__(self, other: object) -> bool:
-        if not isinstance(other, Version):
-            return False
-        return self._as_tuple() <= other._as_tuple()
-
-    def major_differs(self, other: Version) -> bool:
-        return self.major != other.major
-
-    def major_lt(self, other: Version) -> bool:
-        return self.major < other.major
-
-    def minor_differs(self, other: Version) -> bool:
-        return self.minor != other.minor
-
-    def minor_lt(self, other: Version) -> bool:
-        return self.minor < other.minor
-
-    def patch_differs(self, other: Version) -> bool:
-        return self.patch != other.patch
-
-    def minor_or_patch_differs(self, other: Version) -> bool:
-        return self.minor_differs(other) or self.patch_differs(other)
 
 
 class ClientConfig(NamedTuple):
@@ -258,7 +181,7 @@ class ClientConfig(NamedTuple):
         jwtoken: str | None,
         ssl_verify: bool | str | None,
         allow_inputs: bool | None = None,
-    ) -> "ClientConfig":
+    ) -> ClientConfig:
         config = {
             "url": url,
             "username": username,
@@ -371,8 +294,7 @@ class ClientLibrary:
             self._session = make_session(base_url, ssl_verify, client_type)
         except httpx.InvalidURL as exc:
             raise InitializationError(exc) from None
-        # checks version from system_info against self.VERSION
-        controller_version = self.check_controller_version()
+        self._session.controller_version = self.check_controller_version()
 
         self._session.auth = TokenAuth(self)
         # Note: session.auth is defined in the httpx module to be of type Auth,
@@ -404,7 +326,9 @@ class ClientLibrary:
         )
 
         try:
-            self._make_test_auth_call(controller_version >= Version("2.10.0"))
+            self._make_test_auth_call(
+                self._session.controller_version >= Version("2.10.0")
+            )
         except InitializationError as exc:
             if raise_for_auth_failure:
                 raise
@@ -494,25 +418,29 @@ class ClientLibrary:
         url = self._url_for("system_info")
         return self._session.get(url).json()
 
-    def check_controller_version(self) -> Version | None:
+    def check_controller_version(self) -> Version:
         """
         Check remote controller version against current client version
         (specified in self.VERSION and support last 3 minor versions).
         Raise exception if versions are incompatible, or print warning
         if the client minor version is lower than the controller minor version.
-        These all are disabled if self.check_version attribute is set to False.
+        Compatibility validation is disabled if `self.check_version` attribute
+        is set to False, but the version is always parsed and returned.
 
-        :raises InitializationError: If the controller version is incompatible.
+        :raises InitializationError: If the controller version is unparseable
+            or incompatible.
+        :returns: The controller version.
         """
         controller_version_str = self.system_info().get("version", "")
         try:
             controller_version = Version(controller_version_str)
         except (TypeError, ValueError):
-            _LOGGER.warning(f"Invalid version detected: {controller_version_str}!")
-            return None
+            raise InitializationError(
+                f"Controller returned invalid version: {controller_version_str}"
+            )
 
         if not self.check_version:
-            return None
+            return controller_version
 
         if self.VERSION.major_lt(controller_version):
             raise InitializationError(


### PR DESCRIPTION
- Move Version class from virl2_client.py to utils.py to avoid circular imports
- Add FeatureNotSupported exception and requires_version decorator to guard features that need CML >= 2.9 (clone_image, lab repositories)
- Store controller_version on session; always parse even with check_version=False
- Add respx-based backward compat tests (auth branching, version guards, response shape tolerance, 404 handling)
- Add API contract tests to verify public surface stability