### PR TITLE
Rename `id` parameters, fix LabRepository ownership, and protect object IDs

### DIFF
--- a/tests/test_backward_compat.py
+++ b/tests/test_backward_compat.py
@@ -21,7 +21,7 @@
 """Backward compatibility tests for virl2_client 2.10.
 
 These tests verify that the v2.10 client works correctly against older
-CML servers (2.8, 2.9) by mocking server responses with ``respx``.
+CML servers (2.8, 2.9) by mocking server responses with respx.
 
 Tests cover:
 - Auth flow branching (authok vs authentication endpoint)

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -240,6 +240,19 @@ def test_interface_update_push() -> None:
     assert interface.label == "ethX"
 
 
+def test_interface_update_preserves_id() -> None:
+    """_update must not overwrite interface ID.
+
+    NOTE: LLM-generated test -- verify for correctness.
+    """
+    lab = make_lab()
+    node = lab._create_node_local("n1", "node1", "iosv")
+    interface = lab._create_interface_local("if1", "eth0", node, 0)
+    interface._update({"id": "changed", "label": "ethX"}, push_to_server=False)
+    assert interface.id == "if1"
+    assert interface.label == "ethX"
+
+
 def test_interface_set_prop_patches() -> None:
     """_set_interface_property triggers PATCH.
 

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -395,6 +395,22 @@ def test_node_update_excludes_config() -> None:
     assert node.label == "updated-label"
 
 
+def test_node_update_preserves_id() -> None:
+    """_update must not overwrite node ID.
+
+    NOTE: LLM-generated test -- verify for correctness.
+    """
+    _lab, node = _make_lab_and_node()
+    assert node.id == "n1"
+    node._update(
+        {"data": {"id": "changed", "label": "new"}},
+        exclude_configurations=True,
+        push_to_server=False,
+    )
+    assert node.id == "n1"
+    assert node.label == "new"
+
+
 def test_node_is_active_is_booted() -> None:
     """is_active when STARTED, is_booted when BOOTED.
 

--- a/tests/test_resource_pool.py
+++ b/tests/test_resource_pool.py
@@ -296,6 +296,31 @@ def test_rp_update_local_only() -> None:
     assert pool._description == "desc"
 
 
+def test_rp_update_preserves_id() -> None:
+    """_update must not overwrite resource pool ID.
+
+    NOTE: LLM-generated test -- verify for correctness.
+    """
+    manager = ResourcePoolManagement(MagicMock(), auto_sync=False)
+    pool = ResourcePool(
+        manager,
+        pool_id="pool-1",
+        label="Pool",
+        description=None,
+        template=None,
+        licenses=None,
+        ram=None,
+        cpus=None,
+        disk_space=None,
+        external_connectors=None,
+        users=None,
+        user_pools=None,
+    )
+    pool._update({"id": "changed", "description": "new"}, push_to_server=False)
+    assert pool.id == "pool-1"
+    assert pool._description == "new"
+
+
 def test_rp_connectors_returns_copy() -> None:
     """external_connectors returns a copy; mutating it does not affect pool.
 

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -21,6 +21,7 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -28,6 +29,32 @@ import pytest
 from virl2_client.exceptions import ControllerNotFound
 from virl2_client.models.system import ComputeHost, SystemManagement, SystemNotice
 from virl2_client.utils import OptInStatus
+
+
+def _notice_data(notice_id: str = "n1", **overrides: Any) -> dict[str, Any]:
+    """Build a notice data dict matching the API response shape.
+
+    :param notice_id: Notice identifier.
+    :param overrides: Fields to override.
+    :returns: A dict with "id" key; pop it and pass the rest as **kwargs.
+    """
+    return {
+        "id": notice_id,
+        "level": "info",
+        "label": "lbl",
+        "content": "content",
+        "enabled": True,
+        "acknowledged": {},
+        **overrides,
+    }
+
+
+def _make_notice(
+    system: SystemManagement, notice_id: str = "n1", **overrides: Any
+) -> SystemNotice:
+    """Create a SystemNotice from API-shaped data."""
+    data = _notice_data(notice_id, **overrides)
+    return SystemNotice(system, data.pop("id"), **data)
 
 
 def _new_compute_host(system: SystemManagement, compute_id: str) -> ComputeHost:
@@ -78,6 +105,32 @@ def test_compute_host_mutation() -> None:
     assert host.admission_state == "ready"
 
 
+def test_system_notice_update_preserves_id() -> None:
+    """_update must not overwrite notice ID.
+
+    NOTE: LLM-generated test -- verify for correctness.
+    """
+    session = MagicMock()
+    system = SystemManagement(session, auto_sync=False)
+    notice = _make_notice(system, "n1")
+    notice._update({"id": "changed", "level": "warning"}, push_to_server=False)
+    assert notice.id == "n1"
+    assert notice._level == "warning"
+
+
+def test_compute_host_update_preserves_id() -> None:
+    """_update must not overwrite compute host ID.
+
+    NOTE: LLM-generated test -- verify for correctness.
+    """
+    session = MagicMock()
+    system = SystemManagement(session, auto_sync=False)
+    host = _new_compute_host(system, "c1")
+    host._update({"id": "changed", "hostname": "new-host"}, push_to_server=False)
+    assert host.compute_id == "c1"
+    assert host._hostname == "new-host"
+
+
 def test_system_notice_mutation() -> None:
     """System notice label, content, level setters.
 
@@ -85,15 +138,7 @@ def test_system_notice_mutation() -> None:
     """
     session = MagicMock()
     system = SystemManagement(session, auto_sync=False)
-    notice = SystemNotice(
-        system,
-        "n1",
-        "info",
-        "lbl",
-        "content",
-        True,
-        acknowledged={},
-    )
+    notice = _make_notice(system, "n1")
     session.patch.return_value.json.return_value = {"content": "new-content"}
     notice._set_notice_properties({"content": "new-content"})
     assert notice.content == "new-content"
@@ -106,11 +151,7 @@ def test_maintenance_mode_notice() -> None:
     """
     session = MagicMock()
     system = SystemManagement(session, auto_sync=False)
-    system._system_notices = {
-        "n1": SystemNotice(
-            system, "n1", "info", "lbl", "content", True, acknowledged={}
-        )
-    }
+    system._system_notices = {"n1": _make_notice(system, "n1")}
     session.patch.return_value.json.return_value = {"resolved_notice": None}
     system.maintenance_mode = True
     assert system.maintenance_mode is True
@@ -125,11 +166,7 @@ def test_sync_notices_if_outdated() -> None:
     """
     session = MagicMock()
     system = SystemManagement(session, auto_sync=False)
-    system._system_notices = {
-        "n1": SystemNotice(
-            system, "n1", "info", "lbl", "content", True, acknowledged={}
-        )
-    }
+    system._system_notices = {"n1": _make_notice(system, "n1")}
     existing = system._system_notices["n1"]
     system.auto_sync = True
     system.auto_sync_interval = 0
@@ -177,15 +214,7 @@ def test_notice_id_property() -> None:
     """
     session = MagicMock()
     system = SystemManagement(session, auto_sync=False)
-    notice = SystemNotice(
-        system,
-        "n9",
-        "info",
-        "lbl",
-        "content",
-        True,
-        acknowledged={},
-    )
+    notice = _make_notice(system, "n9")
     assert notice.id == "n9"
     session.patch.return_value.json.return_value = {"label": "updated"}
     notice._set_notice_property("label", "updated")
@@ -225,9 +254,7 @@ def test_sync_notices_removes_stale() -> None:
     """
     session = MagicMock()
     system = SystemManagement(session, auto_sync=False)
-    stale_notice = SystemNotice(
-        system, "stale", "info", "old", "content", True, acknowledged={}
-    )
+    stale_notice = _make_notice(system, "stale", label="old")
     system._system_notices = {"stale": stale_notice}
     session.get.side_effect = [
         MagicMock(json=MagicMock(return_value=[])),

--- a/tests/test_system_lab_repositories.py
+++ b/tests/test_system_lab_repositories.py
@@ -27,7 +27,6 @@ import respx
 
 from virl2_client.exceptions import ElementNotFound, LabRepositoryNotFound
 from virl2_client.models.lab_repository import LabRepository, LabRepositoryManagement
-from virl2_client.models.system import SystemManagement
 from virl2_client.virl2_client import ClientLibrary
 
 MOCK_LAB_REPOSITORY_1 = {
@@ -60,17 +59,6 @@ def mock_lab_repository_management() -> LabRepositoryManagement:
 
 
 @pytest.fixture
-def mock_system_management() -> SystemManagement:
-    """Create a mocked SystemManagement model.
-
-    :returns: A SystemManagement instance with mocked session.
-    """
-    session_mock = Mock()
-    system = SystemManagement(session=session_mock, auto_sync=False)
-    return system
-
-
-@pytest.fixture
 def system_with_repos(
     mock_lab_repository_management: LabRepositoryManagement,
 ) -> LabRepositoryManagement:
@@ -81,61 +69,63 @@ def system_with_repos(
     """
     lab_repo_mgmt = mock_lab_repository_management
     for repo_data in MOCK_LAB_REPOSITORIES_LIST:
-        lab_repo_mgmt.add_lab_repository_local(**repo_data)
+        data = dict(repo_data)
+        lab_repo_mgmt.add_lab_repository_local(data.pop("id"), **data)
     return lab_repo_mgmt
 
 
 def test_lab_repository_initialization(
-    mock_system_management: SystemManagement,
+    mock_lab_repository_management: LabRepositoryManagement,
 ) -> None:
     """Validate LabRepository initialization and identity fields.
 
-    :param mock_system_management: Backing system model fixture.
+    :param mock_lab_repository_management: Repository manager fixture.
     """
-    repo = LabRepository(
-        system=mock_system_management,
-        id="test-id",
-        url="https://github.com/test/repo.git",
-        name="test-repo",
-        folder="test_folder",
-    )
+    data = dict(MOCK_LAB_REPOSITORY_1)
+    repo = LabRepository(mock_lab_repository_management, data.pop("id"), **data)
 
-    assert repo.id == "test-id"
-    assert repo._url == "https://github.com/test/repo.git"
-    assert repo._name == "test-repo"
-    assert repo._folder == "test_folder"
-    assert repo._system is mock_system_management
-    assert str(repo) == "Lab repository: test-repo"
+    assert repo.id == MOCK_LAB_REPOSITORY_1["id"]
+    assert repo._url == MOCK_LAB_REPOSITORY_1["url"]
+    assert repo._name == MOCK_LAB_REPOSITORY_1["name"]
+    assert repo._folder == MOCK_LAB_REPOSITORY_1["folder"]
+    assert repo._manager is mock_lab_repository_management
+    assert str(repo) == f"Lab repository: {MOCK_LAB_REPOSITORY_1['name']}"
 
 
 def test_lab_repo_properties_sync(
-    mock_system_management: SystemManagement,
+    mock_lab_repository_management: LabRepositoryManagement,
 ) -> None:
     """Validate sync behavior for id vs mutable repository properties.
 
-    :param mock_system_management: Backing system model fixture.
+    :param mock_lab_repository_management: Repository manager fixture.
     """
     repo = LabRepository(
-        system=mock_system_management,
-        id="test-id",
+        manager=mock_lab_repository_management,
+        repo_id="test-id",
         url="https://github.com/test/repo.git",
         name="test-repo",
         folder="test_folder",
     )
 
-    mock_system_management.sync_lab_repositories_if_outdated = Mock()
+    mock_lab_repository_management.sync_lab_repositories_if_outdated = Mock()
 
     _ = repo.id
-    mock_system_management.sync_lab_repositories_if_outdated.assert_not_called()
+    mock_lab_repository_management.sync_lab_repositories_if_outdated.assert_not_called()
 
     _ = repo.url
-    assert mock_system_management.sync_lab_repositories_if_outdated.call_count == 1
+    assert (
+        mock_lab_repository_management.sync_lab_repositories_if_outdated.call_count == 1
+    )
 
     _ = repo.name
-    assert mock_system_management.sync_lab_repositories_if_outdated.call_count == 2
+    assert (
+        mock_lab_repository_management.sync_lab_repositories_if_outdated.call_count == 2
+    )
 
     _ = repo.folder
-    assert mock_system_management.sync_lab_repositories_if_outdated.call_count == 3
+    assert (
+        mock_lab_repository_management.sync_lab_repositories_if_outdated.call_count == 3
+    )
 
 
 def test_lab_repository_remove(
@@ -147,8 +137,8 @@ def test_lab_repository_remove(
     """
     lab_repo_mgmt = mock_lab_repository_management
     repo = LabRepository(
-        system=lab_repo_mgmt,
-        id="test-id",
+        manager=lab_repo_mgmt,
+        repo_id="test-id",
         url="https://github.com/test/repo.git",
         name="test-repo",
         folder="test_folder",
@@ -226,7 +216,8 @@ def test_add_lab_repository_local(
     """
     lab_repo_mgmt = mock_lab_repository_management
 
-    repo = lab_repo_mgmt.add_lab_repository_local(**MOCK_LAB_REPOSITORY_1)
+    data = dict(MOCK_LAB_REPOSITORY_1)
+    repo = lab_repo_mgmt.add_lab_repository_local(data.pop("id"), **data)
 
     assert isinstance(repo, LabRepository)
     assert repo.id == "repo-123"
@@ -320,7 +311,7 @@ def test_add_lab_repository_api_call(
     lab_repo_mgmt = mock_lab_repository_management
 
     mock_response = Mock()
-    mock_response.json.return_value = MOCK_LAB_REPOSITORY_1
+    mock_response.json.return_value = dict(MOCK_LAB_REPOSITORY_1)
     lab_repo_mgmt._session.post.return_value = mock_response
 
     lab_repo_mgmt._url_for = Mock(return_value="lab_repos")
@@ -332,17 +323,20 @@ def test_add_lab_repository_api_call(
         folder="cisco_labs",
     )
 
-    assert result == MOCK_LAB_REPOSITORY_1
-    lab_repo_mgmt._url_for.assert_called_once_with("lab_repos")
     expected_data = {
         "url": "https://github.com/cisco/lab-templates.git",
         "name": "cisco-templates",
         "folder": "cisco_labs",
     }
+    assert result == expected_data
+    lab_repo_mgmt._url_for.assert_called_once_with("lab_repos")
     lab_repo_mgmt._session.post.assert_called_once_with("lab_repos", json=expected_data)
 
     lab_repo_mgmt.add_lab_repository_local.assert_called_once_with(
-        **MOCK_LAB_REPOSITORY_1
+        "repo-123",
+        url="https://github.com/cisco/lab-templates.git",
+        name="cisco-templates",
+        folder="cisco_labs",
     )
 
 
@@ -384,8 +378,10 @@ def test_sync_lab_repositories_behavior(
     mock_time.return_value = 1234567890.0
     lab_repo_mgmt = mock_lab_repository_management
 
-    lab_repo_mgmt.add_lab_repository_local(**MOCK_LAB_REPOSITORY_1)
-    lab_repo_mgmt.add_lab_repository_local(**MOCK_LAB_REPOSITORY_2)
+    data1 = dict(MOCK_LAB_REPOSITORY_1)
+    lab_repo_mgmt.add_lab_repository_local(data1.pop("id"), **data1)
+    data2 = dict(MOCK_LAB_REPOSITORY_2)
+    lab_repo_mgmt.add_lab_repository_local(data2.pop("id"), **data2)
 
     new_repo_data = {
         "id": "repo-789",
@@ -395,7 +391,7 @@ def test_sync_lab_repositories_behavior(
     }
 
     mock_response = Mock()
-    mock_response.json.return_value = [MOCK_LAB_REPOSITORY_1, new_repo_data]
+    mock_response.json.return_value = [dict(MOCK_LAB_REPOSITORY_1), new_repo_data]
     lab_repo_mgmt._session.get.return_value = mock_response
     lab_repo_mgmt._url_for = Mock(return_value="lab_repos")
 
@@ -498,7 +494,8 @@ def test_lab_repository_end_to_end_workflow() -> None:
         name="cisco-templates",
         folder="cisco_labs",
     )
-    assert result == MOCK_LAB_REPOSITORY_1
+    expected = {k: v for k, v in MOCK_LAB_REPOSITORY_1.items() if k != "id"}
+    assert result == expected
 
     repo = lab_repo_mgmt.get_lab_repository("repo-123")
     assert repo.id == "repo-123"
@@ -513,69 +510,6 @@ def test_lab_repository_end_to_end_workflow() -> None:
 
     with pytest.raises(LabRepositoryNotFound):
         lab_repo_mgmt.get_lab_repository("repo-123")
-
-
-def test_lab_repo_property_sync_fallback() -> None:
-    """Use management fallback sync path for repository properties.
-
-    NOTE: LLM-generated test -- verify for correctness.
-
-    :raises AssertionError: If fallback sync hook is not used.
-    """
-
-    class SystemWithManagement:
-        """Simple stand-in without direct sync method."""
-
-        def __init__(self) -> None:
-            """Initialize minimal system stand-in with management container."""
-            self._session = Mock()
-            self.lab_repository_management = Mock()
-
-    system = SystemWithManagement()
-    repo = LabRepository(
-        system=system,
-        id="repo-id",
-        url="https://example/repo.git",
-        name="repo-name",
-        folder="repo-folder",
-    )
-
-    assert repo.url == "https://example/repo.git"
-    assert repo.name == "repo-name"
-    assert repo.folder == "repo-folder"
-    assert (
-        system.lab_repository_management.sync_lab_repositories_if_outdated.call_count
-        == 3
-    )
-
-
-def test_lab_repo_remove_via_mgmt() -> None:
-    """Remove via management fallback uses system._session.delete.
-
-    NOTE: LLM-generated test -- verify for correctness.
-    """
-    mgr = LabRepositoryManagement(system=Mock(), session=Mock(), auto_sync=False)
-
-    class SystemWithManagement:
-        """Simple stand-in that only exposes management container."""
-
-        def __init__(self, management: LabRepositoryManagement) -> None:
-            self._session = Mock()
-            self.lab_repository_management = management
-
-    system = SystemWithManagement(mgr)
-    repo = LabRepository(
-        system=system,
-        id="repo-id",
-        url="https://example/repo.git",
-        name="repo-name",
-        folder="repo-folder",
-    )
-    mgr._lab_repositories["repo-id"] = repo
-    repo._url_for = Mock(return_value="lab_repos/repo-id")
-    repo.remove()
-    system._session.delete.assert_called_once_with("lab_repos/repo-id")
-    assert "repo-id" not in mgr._lab_repositories
 
 
 def test_lab_repo_management_len() -> None:

--- a/virl2_client/models/interface.py
+++ b/virl2_client/models/interface.py
@@ -428,6 +428,8 @@ class Interface:
         if "data" in interface_data:
             interface_data = interface_data["data"]
         for key, value in interface_data.items():
+            if key == "id":
+                continue
             setattr(self, f"_{key}", value)
 
     def _set_interface_property(self, key: str, val: Any) -> None:

--- a/virl2_client/models/lab_repository.py
+++ b/virl2_client/models/lab_repository.py
@@ -40,24 +40,24 @@ class LabRepository:
 
     def __init__(
         self,
-        system: SystemManagement,
-        id: str,
+        manager: LabRepositoryManagement,
+        repo_id: str,
         url: str,
         name: str,
-        folder: str,
+        folder: str | None,
     ) -> None:
         """
         A lab repository, which provides access to lab templates and resources.
 
-        :param system: The SystemManagement instance.
-        :param id: The ID of the lab repository.
+        :param manager: The LabRepositoryManagement instance that owns this repo.
+        :param repo_id: The ID of the lab repository.
         :param url: The URL of the lab repository.
         :param name: The name of the lab repository.
         :param folder: The folder name for the lab repository.
         """
-        self._system = system
-        self._session: httpx.Client = system._session
-        self._id = id
+        self._manager = manager
+        self._session: httpx.Client = manager._session
+        self._id = repo_id
         self._url = url
         self._name = name
         self._folder = folder
@@ -94,10 +94,7 @@ class LabRepository:
 
         :returns: The repository URL. Syncs from server if needed.
         """
-        if hasattr(self._system, "sync_lab_repositories_if_outdated"):
-            self._system.sync_lab_repositories_if_outdated()
-        elif hasattr(self._system, "lab_repository_management"):
-            self._system.lab_repository_management.sync_lab_repositories_if_outdated()
+        self._manager.sync_lab_repositories_if_outdated()
         return self._url
 
     @property
@@ -106,22 +103,16 @@ class LabRepository:
 
         :returns: The repository name. Syncs from server if needed.
         """
-        if hasattr(self._system, "sync_lab_repositories_if_outdated"):
-            self._system.sync_lab_repositories_if_outdated()
-        elif hasattr(self._system, "lab_repository_management"):
-            self._system.lab_repository_management.sync_lab_repositories_if_outdated()
+        self._manager.sync_lab_repositories_if_outdated()
         return self._name
 
     @property
-    def folder(self) -> str:
+    def folder(self) -> str | None:
         """Return the folder name of the lab repository.
 
-        :returns: The folder name. Syncs from server if needed.
+        :returns: The folder name or None. Syncs from server if needed.
         """
-        if hasattr(self._system, "sync_lab_repositories_if_outdated"):
-            self._system.sync_lab_repositories_if_outdated()
-        elif hasattr(self._system, "lab_repository_management"):
-            self._system.lab_repository_management.sync_lab_repositories_if_outdated()
+        self._manager.sync_lab_repositories_if_outdated()
         return self._folder
 
     def remove(self) -> None:
@@ -129,13 +120,7 @@ class LabRepository:
         _LOGGER.info("Removing lab repository %s", self)
         url = self._url_for("lab_repo")
         self._session.delete(url)
-
-        if hasattr(self._system, "_lab_repositories"):
-            if self._id in self._system._lab_repositories:
-                del self._system._lab_repositories[self._id]
-        elif hasattr(self._system, "lab_repository_management"):
-            if self._id in self._system.lab_repository_management._lab_repositories:
-                del self._system.lab_repository_management._lab_repositories[self._id]
+        self._manager._lab_repositories.pop(self._id, None)
 
 
 class LabRepositoryManagement:
@@ -216,9 +201,9 @@ class LabRepositoryManagement:
         lab_repository_ids = []
 
         for lab_repository in lab_repositories:
-            repo_id = lab_repository.get("id")
+            repo_id = lab_repository.pop("id")
             if repo_id not in self._lab_repositories:
-                self.add_lab_repository_local(**lab_repository)
+                self.add_lab_repository_local(repo_id, **lab_repository)
             lab_repository_ids.append(repo_id)
 
         for repo_id in tuple(self._lab_repositories):
@@ -239,7 +224,9 @@ class LabRepositoryManagement:
         return self._session.get(url).json()
 
     @_requires_version("2.9.0")
-    def add_lab_repository(self, url: str, name: str, folder: str) -> dict[str, Any]:
+    def add_lab_repository(
+        self, url: str, name: str, folder: str | None = None
+    ) -> dict[str, Any]:
         """
         Add a lab repository.
 
@@ -247,14 +234,16 @@ class LabRepositoryManagement:
 
         :param url: The URL of the lab repository.
         :param name: The name of the lab repository.
-        :param folder: The folder name for the lab repository.
+        :param folder: The folder name for the lab repository. (Optional)
         :returns: The created lab repository data.
         """
         repo_url = self._url_for("lab_repos")
-        data = {"url": url, "name": name, "folder": folder}
+        data: dict[str, Any] = {"url": url, "name": name}
+        if folder is not None:
+            data["folder"] = folder
         result = self._session.post(repo_url, json=data).json()
-
-        self.add_lab_repository_local(**result)
+        repo_id = result.pop("id")
+        self.add_lab_repository_local(repo_id, **result)
         return result
 
     @_requires_version("2.9.0")
@@ -271,22 +260,22 @@ class LabRepositoryManagement:
 
     def add_lab_repository_local(
         self,
-        id: str,
+        repo_id: str,
         url: str,
         name: str,
-        folder: str,
+        folder: str | None = None,
     ) -> LabRepository:
         """
         Add a lab repository locally.
 
-        :param id: The unique identifier of the lab repository.
+        :param repo_id: The unique identifier of the lab repository.
         :param url: The URL of the lab repository.
         :param name: The name of the lab repository.
         :param folder: The folder name for the lab repository.
         :returns: The newly created lab repository object.
         """
-        new_lab_repository = LabRepository(self._system, id, url, name, folder)
-        self._lab_repositories[id] = new_lab_repository
+        new_lab_repository = LabRepository(self, repo_id, url, name, folder)
+        self._lab_repositories[repo_id] = new_lab_repository
         return new_lab_repository
 
     def get_lab_repository(self, repo_id: str) -> LabRepository:

--- a/virl2_client/models/node.py
+++ b/virl2_client/models/node.py
@@ -1191,6 +1191,8 @@ class Node:
             node_data = node_data["data"]
 
         for key, value in node_data.items():
+            if key == "id":
+                continue
             if key == "configuration":
                 if not exclude_configurations:
                     self._set_configuration(value)

--- a/virl2_client/models/resource_pool.py
+++ b/virl2_client/models/resource_pool.py
@@ -113,11 +113,10 @@ class ResourcePoolManagement:
         # update existing pools and add entries for new pools
         for res_pool in res_pools:
             pool_id = res_pool.pop("id")
-            res_pool["pool_id"] = pool_id
             if pool_id in self._resource_pools:
                 self._resource_pools[pool_id]._update(res_pool, push_to_server=False)
             else:
-                self._add_resource_pool_local(**res_pool)
+                self._add_resource_pool_local(pool_id, **res_pool)
             res_pool_ids.append(pool_id)
         # remove all local pools that don't exist on remove
         for local_res_pool_id in tuple(self._resource_pools):
@@ -163,8 +162,8 @@ class ResourcePoolManagement:
         kwargs["label"] = label
         url = self._url_for("resource_pools")
         response: dict = self._session.post(url, json=kwargs).json()
-        response["pool_id"] = response.pop("id")
-        return self._add_resource_pool_local(**response)
+        pool_id = response.pop("id")
+        return self._add_resource_pool_local(pool_id, **response)
 
     def create_resource_pools(
         self,
@@ -193,8 +192,8 @@ class ResourcePoolManagement:
 
         result = []
         for pool in response:
-            pool["pool_id"] = pool.pop("id")
-            result.append(self._add_resource_pool_local(**pool))
+            pool_id = pool.pop("id")
+            result.append(self._add_resource_pool_local(pool_id, **pool))
         return result
 
     def _add_resource_pool_local(
@@ -544,6 +543,8 @@ class ResourcePool:
             self._set_resource_pool_properties(pool_data)
 
         for key, value in pool_data.items():
+            if key == "id":
+                continue
             setattr(self, f"_{key}", value)
 
     def _set_resource_pool_property(self, key: str, val: Any) -> None:

--- a/virl2_client/models/system.py
+++ b/virl2_client/models/system.py
@@ -219,14 +219,13 @@ class SystemManagement:
         for compute_host in compute_hosts:
             compute_host.pop("nodes", None)  # removed in 2.10
             compute_id = compute_host.pop("id")
-            compute_host["compute_id"] = compute_id
             if compute_id in self._compute_hosts:
                 self._compute_hosts[compute_id]._update(
                     compute_host, push_to_server=False
                 )
             else:
-                compute_host["node_counts"] = compute_host.get("node_counts", {})
-                self.add_compute_host_local(**compute_host)
+                compute_host.setdefault("node_counts", {})
+                self.add_compute_host_local(compute_id, **compute_host)
             compute_host_ids.append(compute_id)
 
         for compute_id in tuple(self._compute_hosts):
@@ -244,13 +243,13 @@ class SystemManagement:
         system_notice_ids = []
 
         for system_notice in system_notices:
-            notice_id = system_notice.get("id")
+            notice_id = system_notice.pop("id")
             if notice_id in self._system_notices:
                 self._system_notices[notice_id]._update(
                     system_notice, push_to_server=False
                 )
             else:
-                self.add_system_notice_local(**system_notice)
+                self.add_system_notice_local(notice_id, **system_notice)
             system_notice_ids.append(notice_id)
 
         for notice_id in tuple(self._system_notices):
@@ -387,18 +386,18 @@ class SystemManagement:
 
     def add_system_notice_local(
         self,
-        id: str,
+        notice_id: str,
         level: str,
         label: str,
         content: str,
         enabled: bool,
-        acknowledged: dict[str, bool],
+        acknowledged: dict[str, bool] | None = None,
         groups: list[str] | None = None,
     ) -> SystemNotice:
         """
         Add a system notice locally.
 
-        :param id: The unique identifier of the system notice.
+        :param notice_id: The unique identifier of the system notice.
         :param level: The level of the system notice.
         :param label: The label or title of the system notice.
         :param content: The content or description of the system notice.
@@ -411,7 +410,7 @@ class SystemManagement:
         """
         new_system_notice = SystemNotice(
             self,
-            id,
+            notice_id,
             level,
             label,
             content,
@@ -419,7 +418,7 @@ class SystemManagement:
             acknowledged,
             groups,
         )
-        self._system_notices[id] = new_system_notice
+        self._system_notices[notice_id] = new_system_notice
         return new_system_notice
 
 
@@ -594,6 +593,8 @@ class ComputeHost:
             return
 
         for key, value in host_data.items():
+            if key == "id":
+                continue
             setattr(self, f"_{key}", value)
 
     def _set_compute_host_property(self, key: str, val: Any) -> None:
@@ -626,7 +627,7 @@ class SystemNotice:
         label: str,
         content: str,
         enabled: bool,
-        acknowledged: dict[str, bool],
+        acknowledged: dict[str, bool] | None = None,
         groups: list[str] | None = None,
     ) -> None:
         """
@@ -648,7 +649,7 @@ class SystemNotice:
         self._label = label
         self._content = content
         self._enabled = enabled
-        self._acknowledged = acknowledged
+        self._acknowledged = acknowledged or {}
         self._groups = groups
 
     def _url_for(self, endpoint: str, **kwargs: str) -> str:
@@ -748,6 +749,8 @@ class SystemNotice:
             return
 
         for key, value in notice_data.items():
+            if key == "id":
+                continue
             setattr(self, f"_{key}", value)
 
     def _set_notice_property(self, key: str, val: Any) -> None:

--- a/virl2_client/models/user.py
+++ b/virl2_client/models/user.py
@@ -86,11 +86,11 @@ class UserManagement:
     def get_username(self, user_id: str) -> str | None:
         """Look up a username by user ID from the locally synced user list.
 
-        Triggers a sync if the local list is outdated. Returns ``None`` if
+        Triggers a sync if the local list is outdated. Returns None if
         the *user_id* is not found.
 
         :param user_id: User UUID4.
-        :returns: The username, or ``None`` if not found.
+        :returns: The username, or None if not found.
         """
         self.sync_users_if_outdated()
         user = self._users_by_id.get(user_id)

--- a/virl2_client/utils.py
+++ b/virl2_client/utils.py
@@ -340,9 +340,8 @@ def _deprecated_argument(
 def _requires_version(min_version: str) -> Callable:
     """Decorator that guards a method behind a minimum CML server version.
 
-    If the controller version is older than *min_version*, a
-    ``FeatureNotSupported`` error is raised with a user-friendly message
-    *before* the HTTP call is made.
+    If the controller version is older than *min_version*, a FeatureNotSupported
+    error is raised with a user-friendly message *before* the HTTP call is made.
     """
     min_ver = Version(min_version)
 


### PR DESCRIPTION
- Rename `id` to `notice_id` in SystemNotice and add_system_notice_local (A002)
- Rename `id` to `repo_id` in LabRepository and add_lab_repository_local (A002)
- Change LabRepository to reference its owning LabRepositoryManagement instead of SystemManagement, removing broken hasattr fallback branches
- Prevent _update from overwriting object IDs in Node, Interface, ResourcePool, ComputeHost, and SystemNotice
- Update folder type to str | None in LabRepository