### PR TITLE
CMLDEV-779: Updated _import_lab and _set_owner; Updated failing tests;

### DIFF
--- a/tests/test_lab_lifecycle.py
+++ b/tests/test_lab_lifecycle.py
@@ -413,7 +413,7 @@ def test_sync_topology_500() -> None:
 def test_import_old_schema() -> None:
     """_import_lab handles old schema path for created labs."""
     user_mgmt = MagicMock()
-    user_mgmt.get_username.return_value = "owner-1"
+    user_mgmt.get_user.return_value = {"username": "owner-1"}
     lab = make_lab(user_management=user_mgmt)
     old_schema = {
         "lab_title": "created",
@@ -430,18 +430,20 @@ def test_import_old_schema() -> None:
     lab._import_lab(old_schema, created=True)
     assert lab.title == "created"
     assert lab.owner == "owner-1"
+    assert lab.owner_id == "u1"
     assert lab.autostart["enabled"] is True
     assert lab.node_staging["enabled"] is True
-    user_mgmt.get_username.assert_called_once_with("u1")
+    user_mgmt.get_user.assert_called_once_with("u1")
 
 
 def test_owner_fallback() -> None:
     """Owner fallback when user id not resolved."""
     user_mgmt = MagicMock()
-    user_mgmt.get_username.return_value = None
+    user_mgmt.get_user.side_effect = Exception("User not found")
     lab = make_lab(user_management=user_mgmt)
     lab._set_owner(user_id="missing", user_name="fallback")
     assert lab.owner == "fallback"
+    assert lab.owner_id == "missing"
 
 
 def test_remove_elements_helper() -> None:

--- a/tests/test_lab_lifecycle.py
+++ b/tests/test_lab_lifecycle.py
@@ -413,7 +413,7 @@ def test_sync_topology_500() -> None:
 def test_import_old_schema() -> None:
     """_import_lab handles old schema path for created labs."""
     user_mgmt = MagicMock()
-    user_mgmt.get_user.return_value = {"username": "owner-1"}
+    user_mgmt.get_username.return_value = "owner-1"
     lab = make_lab(user_management=user_mgmt)
     old_schema = {
         "lab_title": "created",
@@ -433,13 +433,13 @@ def test_import_old_schema() -> None:
     assert lab.owner_id == "u1"
     assert lab.autostart["enabled"] is True
     assert lab.node_staging["enabled"] is True
-    user_mgmt.get_user.assert_called_once_with("u1")
+    user_mgmt.get_username.assert_called_once_with("u1")
 
 
 def test_owner_fallback() -> None:
     """Owner fallback when user id not resolved."""
     user_mgmt = MagicMock()
-    user_mgmt.get_user.side_effect = Exception("User not found")
+    user_mgmt.get_username.return_value = None
     lab = make_lab(user_management=user_mgmt)
     lab._set_owner(user_id="missing", user_name="fallback")
     assert lab.owner == "fallback"

--- a/tests/test_lab_lifecycle.py
+++ b/tests/test_lab_lifecycle.py
@@ -436,14 +436,26 @@ def test_import_old_schema() -> None:
     user_mgmt.get_username.assert_called_once_with("u1")
 
 
-def test_owner_fallback() -> None:
-    """Owner fallback when user id not resolved."""
+def test_set_owner_username_overrides_cache() -> None:
+    """Caller-supplied user_name wins and the cache is not consulted."""
+    user_mgmt = MagicMock()
+    user_mgmt.get_username.return_value = "from-cache"
+    lab = make_lab(user_management=user_mgmt)
+    lab._set_owner(user_id="u1", user_name="from-response")
+    assert lab.owner == "from-response"
+    assert lab.owner_id == "u1"
+    user_mgmt.get_username.assert_not_called()
+
+
+def test_set_owner_unresolved_user_id_yields_none_owner() -> None:
+    """When only user_id is supplied and the cache misses, owner is None."""
     user_mgmt = MagicMock()
     user_mgmt.get_username.return_value = None
     lab = make_lab(user_management=user_mgmt)
-    lab._set_owner(user_id="missing", user_name="fallback")
-    assert lab.owner == "fallback"
+    lab._set_owner(user_id="missing")
+    assert lab.owner is None
     assert lab.owner_id == "missing"
+    user_mgmt.get_username.assert_called_once_with("missing")
 
 
 def test_remove_elements_helper() -> None:

--- a/tests/test_lab_lifecycle.py
+++ b/tests/test_lab_lifecycle.py
@@ -419,7 +419,7 @@ def test_import_old_schema() -> None:
         "lab_title": "created",
         "lab_description": "desc",
         "lab_notes": "notes",
-        "lab_owner": "u1",
+        "owner": "u1",
         "autostart": {"enabled": True, "priority": 1, "delay": 0},
         "node_staging": {
             "enabled": True,

--- a/tests/test_lab_sync.py
+++ b/tests/test_lab_sync.py
@@ -138,17 +138,32 @@ def test_import_old_schema() -> None:
     user_mgmt.get_username.assert_called_once_with("u1")
 
 
-def test_owner_fallback() -> None:
-    """Owner fallback when user id not resolved.
+def test_set_owner_username_overrides_cache() -> None:
+    """Caller-supplied user_name wins and the cache is not consulted.
+
+    NOTE: LLM-generated test -- verify for correctness.
+    """
+    user_mgmt = MagicMock()
+    user_mgmt.get_username.return_value = "from-cache"
+    lab = make_lab(user_management=user_mgmt)
+    lab._set_owner(user_id="u1", user_name="from-response")
+    assert lab.owner == "from-response"
+    assert lab.owner_id == "u1"
+    user_mgmt.get_username.assert_not_called()
+
+
+def test_set_owner_unresolved_user_id_yields_none_owner() -> None:
+    """When only user_id is supplied and the cache misses, owner is None.
 
     NOTE: LLM-generated test -- verify for correctness.
     """
     user_mgmt = MagicMock()
     user_mgmt.get_username.return_value = None
     lab = make_lab(user_management=user_mgmt)
-    lab._set_owner(user_id="missing", user_name="fallback")
-    assert lab.owner == "fallback"
+    lab._set_owner(user_id="missing")
+    assert lab.owner is None
     assert lab.owner_id == "missing"
+    user_mgmt.get_username.assert_called_once_with("missing")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_lab_sync.py
+++ b/tests/test_lab_sync.py
@@ -115,7 +115,7 @@ def test_import_old_schema() -> None:
     NOTE: LLM-generated test -- verify for correctness.
     """
     user_mgmt = MagicMock()
-    user_mgmt.get_username.return_value = "owner-1"
+    user_mgmt.get_user.return_value = {"username": "owner-1"}
     lab = make_lab(user_management=user_mgmt)
     old_schema = {
         "lab_title": "created",
@@ -132,9 +132,10 @@ def test_import_old_schema() -> None:
     lab._import_lab(old_schema, created=True)
     assert lab.title == "created"
     assert lab.owner == "owner-1"
+    assert lab.owner_id == "u1"
     assert lab.autostart["enabled"] is True
     assert lab.node_staging["enabled"] is True
-    user_mgmt.get_username.assert_called_once_with("u1")
+    user_mgmt.get_user.assert_called_once_with("u1")
 
 
 def test_owner_fallback() -> None:
@@ -143,10 +144,11 @@ def test_owner_fallback() -> None:
     NOTE: LLM-generated test -- verify for correctness.
     """
     user_mgmt = MagicMock()
-    user_mgmt.get_username.return_value = None
+    user_mgmt.get_user.side_effect = Exception("User not found")
     lab = make_lab(user_management=user_mgmt)
     lab._set_owner(user_id="missing", user_name="fallback")
     assert lab.owner == "fallback"
+    assert lab.owner_id == "missing"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_lab_sync.py
+++ b/tests/test_lab_sync.py
@@ -115,7 +115,7 @@ def test_import_old_schema() -> None:
     NOTE: LLM-generated test -- verify for correctness.
     """
     user_mgmt = MagicMock()
-    user_mgmt.get_user.return_value = {"username": "owner-1"}
+    user_mgmt.get_username.return_value = "owner-1"
     lab = make_lab(user_management=user_mgmt)
     old_schema = {
         "lab_title": "created",
@@ -135,7 +135,7 @@ def test_import_old_schema() -> None:
     assert lab.owner_id == "u1"
     assert lab.autostart["enabled"] is True
     assert lab.node_staging["enabled"] is True
-    user_mgmt.get_user.assert_called_once_with("u1")
+    user_mgmt.get_username.assert_called_once_with("u1")
 
 
 def test_owner_fallback() -> None:
@@ -144,7 +144,7 @@ def test_owner_fallback() -> None:
     NOTE: LLM-generated test -- verify for correctness.
     """
     user_mgmt = MagicMock()
-    user_mgmt.get_user.side_effect = Exception("User not found")
+    user_mgmt.get_username.return_value = None
     lab = make_lab(user_management=user_mgmt)
     lab._set_owner(user_id="missing", user_name="fallback")
     assert lab.owner == "fallback"

--- a/tests/test_lab_sync.py
+++ b/tests/test_lab_sync.py
@@ -121,7 +121,7 @@ def test_import_old_schema() -> None:
         "lab_title": "created",
         "lab_description": "desc",
         "lab_notes": "notes",
-        "lab_owner": "u1",
+        "owner": "u1",
         "autostart": {"enabled": True, "priority": 1, "delay": 0},
         "node_staging": {
             "enabled": True,

--- a/tests/test_lab_topology_and_runtime.py
+++ b/tests/test_lab_topology_and_runtime.py
@@ -233,12 +233,15 @@ def test_update_lab_properties() -> None:
     NOTE: LLM-generated test -- verify for correctness.
     """
     lab, _, _ = _make_lab_context()
+    # Mock get_user to return the expected username
+    lab._user_management.get_user.return_value = {"username": "new-owner"}
     lab.update_lab_properties(
         {
             "title": "new-title",
             "description": "new-desc",
             "notes": "new-notes",
-            "owner": "new-owner",
+            "owner": "owner-id-123",
+            "owner_username": "new-owner",
             "autostart": {"enabled": True},
             "node_staging": {
                 "enabled": True,
@@ -251,6 +254,7 @@ def test_update_lab_properties() -> None:
     assert lab.description == "new-desc"
     assert lab.notes == "new-notes"
     assert lab.owner == "new-owner"
+    assert lab.owner_id == "owner-id-123"
     assert lab.autostart["enabled"] is True
     assert lab.node_staging["enabled"] is True
 

--- a/tests/test_lab_topology_and_runtime.py
+++ b/tests/test_lab_topology_and_runtime.py
@@ -233,14 +233,14 @@ def test_update_lab_properties() -> None:
     NOTE: LLM-generated test -- verify for correctness.
     """
     lab, _, _ = _make_lab_context()
-    lab._user_management.get_username.return_value = "new-owner"
+    lab._user_management.get_username.return_value = "from-cache"
     lab.update_lab_properties(
         {
             "title": "new-title",
             "description": "new-desc",
             "notes": "new-notes",
             "owner": "owner-id-123",
-            "owner_username": "new-owner",
+            "owner_username": "from-response",
             "autostart": {"enabled": True},
             "node_staging": {
                 "enabled": True,
@@ -252,8 +252,10 @@ def test_update_lab_properties() -> None:
     assert lab.title == "new-title"
     assert lab.description == "new-desc"
     assert lab.notes == "new-notes"
-    assert lab.owner == "new-owner"
+    # Response-supplied username wins over the cached value (no cache lookup).
+    assert lab.owner == "from-response"
     assert lab.owner_id == "owner-id-123"
+    lab._user_management.get_username.assert_not_called()
     assert lab.autostart["enabled"] is True
     assert lab.node_staging["enabled"] is True
 

--- a/tests/test_lab_topology_and_runtime.py
+++ b/tests/test_lab_topology_and_runtime.py
@@ -233,8 +233,7 @@ def test_update_lab_properties() -> None:
     NOTE: LLM-generated test -- verify for correctness.
     """
     lab, _, _ = _make_lab_context()
-    # Mock get_user to return the expected username
-    lab._user_management.get_user.return_value = {"username": "new-owner"}
+    lab._user_management.get_username.return_value = "new-owner"
     lab.update_lab_properties(
         {
             "title": "new-title",

--- a/virl2_client/models/lab.py
+++ b/virl2_client/models/lab.py
@@ -1679,8 +1679,12 @@ class Lab:
 
             # API returns both "owner" (ID) and "owner_username"
             owner_id = topology.get("owner") or topology.get("lab_owner")
-            owner_username = topology.get("owner_username", default_owner)
-            self._set_owner(owner_id, owner_username)
+            owner_username = topology.get("owner_username")
+            if owner_username:
+                self._owner = owner_username
+                self._owner_id = owner_id
+            else:
+                self._set_owner(owner_id, default_owner)
 
             if autostart := topology.get("autostart"):
                 self._autostart = autostart
@@ -2211,7 +2215,11 @@ class Lab:
         if "owner" in properties:
             owner_id = properties.get("owner")
             owner_username = properties.get("owner_username")
-            self._set_owner(owner_id, owner_username)
+            if owner_username:
+                self._owner = owner_username
+                self._owner_id = owner_id
+            else:
+                self._set_owner(owner_id)
 
         self._autostart.update(properties.get("autostart", {}))
 
@@ -2481,20 +2489,18 @@ class Lab:
         self, user_id: str | None = None, user_name: str | None = None
     ) -> None:
         """
-        Sets the owner ID and username. If user_id is provided, fetches the user
-        information directly from the API to get the username. Falls back to the
-        provided user_name if the ID is None or the user doesn't exist.
+        Sets the owner ID and username. If user_id is provided, uses the cached
+        user list to resolve the username efficiently. Falls back to the
+        provided user_name if the ID is None or the user doesn't exist in cache.
 
         :param user_id: User unique identifier.
-        :param user_name: Username.
+        :param user_name: Username to use as fallback.
         """
         if user_id:
-            try:
-                user_info = self._user_management.get_user(user_id)
-                user_name = user_info.get("username")
-                self._owner_id = user_id
-            except Exception:
-                self._owner_id = user_id if user_name else None
+            resolved = self._user_management.get_username(user_id)
+            if resolved is not None:
+                user_name = resolved
+            self._owner_id = user_id
         else:
             self._owner_id = None
         self._owner = user_name

--- a/virl2_client/models/lab.py
+++ b/virl2_client/models/lab.py
@@ -1659,14 +1659,13 @@ class Lab:
         Replace lab properties with the given topology.
 
         :param topology: The topology to import.
-        :param created: The node create API endpoint returns data in the old format,
-            which would print an unnecessary old schema warning;
-            setting this flag to True skips that warning. Also decides whether default
-            username is to be the current user or None.
+        :param created: Whether the topology came from the lab create endpoint,
+            which returns the lab metadata flat at the top level rather than
+            nested under "lab". Setting this flag to True skips the
+            InvalidTopologySchema raise for that flat shape.
         :raises KeyError: If any property is missing in the topology.
         """
         lab_dict = topology.get("lab")
-        default_owner = self.username if created else None
 
         if lab_dict is None:
             # Some endpoints (e.g. lab create / GET /labs/{id}) return the lab
@@ -1677,7 +1676,7 @@ class Lab:
                 "title": topology["lab_title"],
                 "description": topology["lab_description"],
                 "notes": topology["lab_notes"],
-                "owner": topology.get("owner") or topology.get("lab_owner"),
+                "owner": topology.get("owner"),
                 "owner_username": topology.get("owner_username"),
                 "node_staging": topology.get("node_staging"),
                 "autostart": topology.get("autostart"),
@@ -1686,10 +1685,7 @@ class Lab:
         self._title = lab_dict["title"]
         self._description = lab_dict["description"]
         self._notes = lab_dict["notes"]
-        self._set_owner(
-            lab_dict.get("owner"),
-            lab_dict.get("owner_username") or default_owner,
-        )
+        self._set_owner(lab_dict.get("owner"), lab_dict.get("owner_username"))
 
         if autostart := lab_dict.get("autostart"):
             self._autostart = autostart
@@ -2484,18 +2480,16 @@ class Lab:
         self, user_id: str | None = None, user_name: str | None = None
     ) -> None:
         """
-        Sets the owner ID and username. If user_id is provided, uses the cached
-        user list to resolve the username efficiently. Falls back to the
-        provided user_name if the ID is None or the user doesn't exist in cache.
+        Set the lab owner ID and username.
+
+        When *user_name* is supplied, it is used as-is and the cache is not
+        consulted. When only *user_id* is supplied, the username is resolved
+        from the cached user list. Passing both as None clears both attributes.
 
         :param user_id: User unique identifier.
-        :param user_name: Username to use as fallback.
+        :param user_name: Username (preferred when set; skips the cache lookup).
         """
-        if user_id:
-            resolved = self._user_management.get_username(user_id)
-            if resolved is not None:
-                user_name = resolved
-            self._owner_id = user_id
-        else:
-            self._owner_id = None
+        self._owner_id = user_id or None
+        if user_name is None and user_id:
+            user_name = self._user_management.get_username(user_id)
         self._owner = user_name

--- a/virl2_client/models/lab.py
+++ b/virl2_client/models/lab.py
@@ -156,6 +156,7 @@ class Lab:
         self._id = lab_id
         self._session = session
         self._owner = username
+        self._owner_id = None
         self._state = None
         self._nodes: dict[str, Node] = {}
         """
@@ -508,6 +509,16 @@ class Lab:
         """
         self.sync_topology_if_outdated()
         return self._owner
+
+    @property
+    def owner_id(self) -> str | None:
+        """
+        Return the owner ID of the lab.
+
+        :returns: The lab owner user ID, or None if not set.
+        """
+        self.sync_topology_if_outdated()
+        return self._owner_id
 
     @property
     def resource_pools(self) -> list[ResourcePool]:
@@ -1658,14 +1669,19 @@ class Lab:
         default_owner = self.username if created else None
 
         if lab_dict is None:
-            # If we just created the lab, we skip the warning, since the
-            # lab post endpoint returns data in the old format
+            # Create endpoint returns data with lab_title, lab_description, etc.
+            # at the top level (old schema format)
             if not created:
                 raise InvalidTopologySchema
             self._title = topology["lab_title"]
             self._description = topology["lab_description"]
             self._notes = topology["lab_notes"]
-            self._set_owner(topology.get("lab_owner"), default_owner)
+
+            # API returns both "owner" (ID) and "owner_username"
+            owner_id = topology.get("owner") or topology.get("lab_owner")
+            owner_username = topology.get("owner_username", default_owner)
+            self._set_owner(owner_id, owner_username)
+
             if autostart := topology.get("autostart"):
                 self._autostart = autostart
             node_staging = topology.get("node_staging")
@@ -2191,7 +2207,12 @@ class Lab:
         self._title = properties.get("title", self._title)
         self._description = properties.get("description", self._description)
         self._notes = properties.get("notes", self._notes)
-        self._owner = properties.get("owner", self._owner)
+
+        if "owner" in properties:
+            owner_id = properties.get("owner")
+            owner_username = properties.get("owner_username")
+            self._set_owner(owner_id, owner_username)
+
         self._autostart.update(properties.get("autostart", {}))
 
         # Handle node staging properties
@@ -2460,15 +2481,20 @@ class Lab:
         self, user_id: str | None = None, user_name: str | None = None
     ) -> None:
         """
-        Sets the owner to the name of the user specified by the provided user_id.
-        If given ID is None/doesn't exist, we fall back to the given user_name,
-        which will usually be the name of the current user or None.
+        Sets the owner ID and username. If user_id is provided, fetches the user
+        information directly from the API to get the username. Falls back to the
+        provided user_name if the ID is None or the user doesn't exist.
 
         :param user_id: User unique identifier.
         :param user_name: Username.
         """
         if user_id:
-            resolved = self._user_management.get_username(user_id)
-            if resolved is not None:
-                user_name = resolved
+            try:
+                user_info = self._user_management.get_user(user_id)
+                user_name = user_info.get("username")
+                self._owner_id = user_id
+            except Exception:
+                self._owner_id = user_id if user_name else None
+        else:
+            self._owner_id = None
         self._owner = user_name

--- a/virl2_client/models/lab.py
+++ b/virl2_client/models/lab.py
@@ -501,11 +501,14 @@ class Lab:
             setattr(self, f"_{prop}", value)
 
     @property
-    def owner(self) -> str:
+    def owner(self) -> str | None:
         """
-        Return the owner of the lab.
+        Return the owner username of the lab.
 
-        :returns: The lab owner username.
+        :returns: The lab owner username, or None when the owner's id could
+            not be resolved against the user cache (e.g. the API returned an
+            owner id but no ``owner_username`` and the user is unknown to
+            the cache).
         """
         self.sync_topology_if_outdated()
         return self._owner

--- a/virl2_client/models/lab.py
+++ b/virl2_client/models/lab.py
@@ -1669,34 +1669,32 @@ class Lab:
         default_owner = self.username if created else None
 
         if lab_dict is None:
-            # Create endpoint returns data with lab_title, lab_description, etc.
-            # at the top level (old schema format)
+            # Some endpoints (e.g. lab create / GET /labs/{id}) return the lab
+            # metadata flat at the top level rather than nested under "lab".
             if not created:
                 raise InvalidTopologySchema
-            self._title = topology["lab_title"]
-            self._description = topology["lab_description"]
-            self._notes = topology["lab_notes"]
+            lab_dict = {
+                "title": topology["lab_title"],
+                "description": topology["lab_description"],
+                "notes": topology["lab_notes"],
+                "owner": topology.get("owner") or topology.get("lab_owner"),
+                "owner_username": topology.get("owner_username"),
+                "node_staging": topology.get("node_staging"),
+                "autostart": topology.get("autostart"),
+            }
 
-            # API returns both "owner" (ID) and "owner_username"
-            owner_id = topology.get("owner") or topology.get("lab_owner")
-            owner_username = topology.get("owner_username")
-            if owner_username:
-                self._owner = owner_username
-                self._owner_id = owner_id
-            else:
-                self._set_owner(owner_id, default_owner)
+        self._title = lab_dict["title"]
+        self._description = lab_dict["description"]
+        self._notes = lab_dict["notes"]
+        self._set_owner(
+            lab_dict.get("owner"),
+            lab_dict.get("owner_username") or default_owner,
+        )
 
-            if autostart := topology.get("autostart"):
-                self._autostart = autostart
-            node_staging = topology.get("node_staging")
-        else:
-            self._title = lab_dict["title"]
-            self._description = lab_dict["description"]
-            self._notes = lab_dict["notes"]
-            self._set_owner(lab_dict.get("owner"), default_owner)
-            node_staging = lab_dict.get("node_staging")
+        if autostart := lab_dict.get("autostart"):
+            self._autostart = autostart
 
-        if node_staging:
+        if node_staging := lab_dict.get("node_staging"):
             self._node_staging = node_staging
 
     @locked
@@ -2213,13 +2211,10 @@ class Lab:
         self._notes = properties.get("notes", self._notes)
 
         if "owner" in properties:
-            owner_id = properties.get("owner")
-            owner_username = properties.get("owner_username")
-            if owner_username:
-                self._owner = owner_username
-                self._owner_id = owner_id
-            else:
-                self._set_owner(owner_id)
+            self._set_owner(
+                user_id=properties.get("owner"),
+                user_name=properties.get("owner_username"),
+            )
 
         self._autostart.update(properties.get("autostart", {}))
 


### PR DESCRIPTION
Resolves [CMLDEV-779](https://cisco-learning.atlassian.net/browse/CMLDEV-779).

- Adds `Lab.owner_id` property and persists `_owner_id` from `_import_lab`,
  `update_lab_properties`, and `_set_owner`.
- `_set_owner` now records both the resolved username and the user id,
  drops the broken `try/except`, and no longer wipes `_owner_id` after a
  successful resolution.
- Tests updated to assert the new `owner_id` value alongside `owner`.

Follow-up (not in this PR):
- Replace `_set_owner` with an `owner` property setter (per @PatrikMosko's
  review).
- Unify the two `_import_lab` data paths once the backend confirms a
  single response shape.