### PR TITLE
CMLDEV-1054 allow jwt auth for ssh console server pyats

### DIFF
--- a/tests/test_lab_topology_and_runtime.py
+++ b/tests/test_lab_topology_and_runtime.py
@@ -277,17 +277,35 @@ def test_get_pyats_testbed() -> None:
 
 
 def test_sync_and_cleanup_pyats() -> None:
-    """sync_pyats and cleanup_pyats_connections delegate to pyats.
+    """sync_pyats forwards the password, cleanup delegates to pyats.
 
     NOTE: LLM-generated test -- verify for correctness.
     """
     lab, _, _ = _make_lab_context()
     with patch.object(lab.pyats, "sync_testbed") as sync_testbed:
         lab.sync_pyats()
-        sync_testbed.assert_called_once()
+        sync_testbed.assert_called_once_with(lab.username, lab.password)
     with patch.object(lab.pyats, "cleanup") as cleanup:
         lab.cleanup_pyats_connections()
         cleanup.assert_called_once()
+
+
+def test_sync_pyats_falls_back_to_jwt_when_password_missing() -> None:
+    """sync_pyats uses the active JWT when the client has no password.
+
+    Token-only clients (e.g. ClientLibrary initialized via cml_token /
+    jwtoken) leave Lab.password unset.  In that case sync_pyats must
+    fall back to the live JWT on the session's auth handler so the SSH
+    console can verify the token instead of creating a new one.
+
+    NOTE: LLM-generated test -- verify for correctness.
+    """
+    lab, session, _ = _make_lab_context()
+    lab.password = None
+    session.auth.token = "jwt-token-placeholder"
+    with patch.object(lab.pyats, "sync_testbed") as sync_testbed:
+        lab.sync_pyats()
+        sync_testbed.assert_called_once_with(lab.username, "jwt-token-placeholder")
 
 
 def test_associations_crud() -> None:

--- a/tests/test_pyats.py
+++ b/tests/test_pyats.py
@@ -126,8 +126,26 @@ def test_cl_pyats_load_testbed() -> None:
         assert pyats._load_pyats_testbed("devices: {}") == {"tb": "ok"}
 
 
-def test_cl_pyats_sync_testbed() -> None:
+@pytest.mark.parametrize(
+    ("args", "expected"),
+    [
+        pytest.param(("u", "p"), ("u", "p"), id="password"),
+        pytest.param(("u", None), ("u", None), id="password-none"),
+        pytest.param(("u",), ("u", None), id="password-omitted"),
+        pytest.param(
+            ("u", "jwt-token-placeholder"),
+            ("u", "jwt-token-placeholder"),
+            id="password-jwt",
+        ),
+    ],
+)
+def test_cl_pyats_sync_testbed(args: tuple, expected: tuple) -> None:
     """Sync credentials into testbed.
+
+    The password parameter is optional; None is forwarded to
+    set_termserv_credentials so the testbed YAML default is preserved.
+    A JWT string is forwarded verbatim (the SSH console server
+    interprets it).
 
     NOTE: LLM-generated test -- verify for correctness.
     """
@@ -139,9 +157,9 @@ def test_cl_pyats_sync_testbed() -> None:
         patch.object(pyats, "set_termserv_credentials") as set_creds,
     ):
         lab.get_pyats_testbed.return_value = "yaml-data"
-        pyats.sync_testbed("u", "p")
+        pyats.sync_testbed(*args)
         load_tb.assert_called_once_with("yaml-data")
-        set_creds.assert_called_once_with("u", "p")
+        set_creds.assert_called_once_with(*expected)
 
 
 def test_cl_pyats_switch_console() -> None:

--- a/virl2_client/models/cl_pyats.py
+++ b/virl2_client/models/cl_pyats.py
@@ -133,8 +133,12 @@ class ClPyats:
 
         :param username: The username to be inserted into the testbed data.
         :param password: The password or a JWT token to be inserted into
-            the testbed data. The SSH console server accepts a JWT as the
-            password, which avoids creating a new token per SSH session.
+            the testbed data. Passing a JWT avoids creating a new token
+            per SSH session and requires a CML 2.11.0 (or newer)
+            controller that accepts JWTs as SSH passwords. When None
+            (the default), the existing terminal-server password in the
+            testbed YAML is left unchanged; call set_termserv_credentials
+            to set credentials later.
         :raises PyatsNotInstalled: If pyATS is not installed.
         """
         self._check_pyats_installed()

--- a/virl2_client/models/cl_pyats.py
+++ b/virl2_client/models/cl_pyats.py
@@ -127,12 +127,14 @@ class ClPyats:
         loader = _PyatsTFLoader(markupprocessor=processor, enable_extensions=False)
         return loader.load(io.StringIO(testbed_yaml))
 
-    def sync_testbed(self, username: str, password: str) -> None:
+    def sync_testbed(self, username: str, password: str | None = None) -> None:
         """
         Sync the testbed (the latest topology data) from the server.
 
         :param username: The username to be inserted into the testbed data.
-        :param password: The password to be inserted into the testbed data.
+        :param password: The password or a JWT token to be inserted into
+            the testbed data. The SSH console server accepts a JWT as the
+            password, which avoids creating a new token per SSH session.
         :raises PyatsNotInstalled: If pyATS is not installed.
         """
         self._check_pyats_installed()

--- a/virl2_client/models/lab.py
+++ b/virl2_client/models/lab.py
@@ -2352,8 +2352,16 @@ class Lab:
         """
         Sync the pyATS testbed.
 
+        When the client library was initialized with a password, that
+        password is inserted into the testbed as the terminal-server
+        credential.  When it was initialized with a JWT only (no
+        password), the active JWT is used instead; this avoids creating
+        a new token per SSH session and lets token-only clients use
+        pyATS.  Using a JWT requires a CML 2.11.0 (or newer) controller
+        that accepts JWTs as SSH passwords.
         """
-        self.pyats.sync_testbed(self.username, self.password)
+        password = self.password or self._session.auth.token
+        self.pyats.sync_testbed(self.username, password)
 
     def cleanup_pyats_connections(self) -> None:
         """


### PR DESCRIPTION
#### Make sync_testbed password optional for JWT auth support
###### Summary:
- Make `password` parameter optional in `sync_testbed()` to support passing a JWT token as the SSH credential
- The SSH console server (`virl2-sshd`) now accepts JWT tokens as passwords, verifying them instead of creating new tokens per session (see main repo PR #4236)
- Backward compatible — existing `sync_testbed(username, password)` calls work unchanged
###### Changes:
- `virl2_client/models/cl_pyats.py` — `sync_testbed(username, password)` → `sync_testbed(username, password=None)`. Docstring updated to note JWT token can be passed as the password value.