### PR TITLE
CMLDEV-1207: expose per-node QUEUED/STARTED/BOOTED times in PCL

### DIFF
--- a/tests/test_lab_topology_and_runtime.py
+++ b/tests/test_lab_topology_and_runtime.py
@@ -66,7 +66,8 @@ def test_sync_statistics() -> None:
             "n1": {
                 "cpu_usage": "50.5",
                 "block0_rd_bytes": "1048576",
-                "block0_wr_bytes": None,
+                "block0_wr_bytes": "0",
+                "times": {"QUEUED": 25, "STARTED": 200, "BOOTED": 175},
             }
         },
         "links": {
@@ -80,8 +81,111 @@ def test_sync_statistics() -> None:
     }
     lab.sync_statistics()
     assert n1.statistics["cpu_usage"] == 50.5
+    assert n1.statistics["times"] == {"QUEUED": 25, "STARTED": 200, "BOOTED": 175}
     assert link.statistics["readbytes"] == 10
     assert i2.statistics["writebytes"] == 10
+
+
+def test_sync_statistics_handles_payload_without_resource_stats() -> None:
+    """Tolerate ext_conn/UMS/QUEUED node payloads that only carry `times`.
+
+    The CML controller only reports cpu_usage / block0_* for nodes
+    backed by a real VM. External connectors, unmanaged switches, and
+    nodes still in the QUEUED state come back as just ``{"times": ...}``
+    on v2.9 / v2.10 (and ``{"times": ..., "is_running": ...}`` on dev).
+
+    NOTE: LLM-generated test -- verify for correctness.
+    """
+    lab, session, _ = _make_lab_context()
+    ext_conn = lab._create_node_local("ec", "ec", "external_connector")
+    ums = lab._create_node_local("us", "us", "unmanaged_switch")
+
+    session.get.return_value.json.return_value = {
+        "nodes": {
+            "ec": {"times": {"QUEUED": 10, "STARTED": 50, "BOOTED": 45}},
+            "us": {
+                "times": {"QUEUED": 12, "STARTED": 40, "BOOTED": 35},
+                "is_running": True,
+            },
+        },
+        "links": {},
+    }
+    lab.sync_statistics()
+    assert ext_conn.statistics["cpu_usage"] == 0
+    assert ext_conn.statistics["disk_read"] == 0
+    assert ext_conn.statistics["disk_write"] == 0
+    assert ext_conn.statistics["times"] == {"QUEUED": 10, "STARTED": 50, "BOOTED": 45}
+    assert ums.statistics["times"] == {"QUEUED": 12, "STARTED": 40, "BOOTED": 35}
+    assert ext_conn.boot_time == 45
+    assert ums.boot_time == 35
+
+
+def test_node_times_properties_expose_simulation_stats() -> None:
+    """Node.times/boot_time/started_time/queued_time mirror simulation_stats.
+
+    NOTE: LLM-generated test -- verify for correctness.
+    """
+    lab, _session, _ = _make_lab_context()
+    n1 = lab._create_node_local("n1", "n1", "iosv")
+    n1.statistics = {
+        "cpu_usage": 0,
+        "disk_read": 0,
+        "disk_write": 0,
+        "times": {"QUEUED": 25, "STARTED": 200, "BOOTED": 175},
+    }
+    with patch.object(lab, "sync_statistics_if_outdated"):
+        assert n1.times == {"QUEUED": 25, "STARTED": 200, "BOOTED": 175}
+        assert n1.boot_time == 175
+        assert n1.started_time == 200
+        assert n1.queued_time == 25
+
+
+def test_node_times_defaults_to_empty_pre_sync() -> None:
+    """Node.times returns {} pre-sync; convenience properties return 0.
+
+    NOTE: LLM-generated test -- verify for correctness.
+    """
+    lab, _session, _ = _make_lab_context()
+    n1 = lab._create_node_local("n1", "n1", "iosv")
+
+    with patch.object(lab, "sync_statistics_if_outdated"):
+        assert n1.times == {}
+        assert n1.boot_time == 0
+        assert n1.started_time == 0
+        assert n1.queued_time == 0
+
+
+def test_lab_uptime_returns_min_started_across_running_nodes() -> None:
+    """Lab.uptime is the smallest Node.started_time when all nodes are running.
+
+    NOTE: LLM-generated test -- verify for correctness.
+    """
+    lab, _session, _ = _make_lab_context()
+    n1 = lab._create_node_local("n1", "n1", "iosv")
+    n2 = lab._create_node_local("n2", "n2", "iosv")
+    n1.statistics["times"] = {"QUEUED": 5, "STARTED": 7200, "BOOTED": 7000}
+    n2.statistics["times"] = {"QUEUED": 8, "STARTED": 600, "BOOTED": 540}
+
+    with patch.object(lab, "sync_statistics_if_outdated"):
+        assert lab.uptime == 600
+
+
+def test_lab_uptime_zero_when_any_node_not_running() -> None:
+    """Lab.uptime is 0 if any node is not running, or the lab is empty.
+
+    NOTE: LLM-generated test -- verify for correctness.
+    """
+    lab, _session, _ = _make_lab_context()
+    assert lab.uptime == 0  # empty lab
+
+    running = lab._create_node_local("n1", "n1", "iosv")
+    queued = lab._create_node_local("n2", "n2", "iosv")
+    running.statistics["times"] = {"QUEUED": 5, "STARTED": 600, "BOOTED": 540}
+    queued.statistics["times"] = {"QUEUED": 30, "STARTED": 0, "BOOTED": 0}
+
+    with patch.object(lab, "sync_statistics_if_outdated"):
+        assert lab.uptime == 0
+        assert queued.started_time == 0
 
 
 def test_sync_states() -> None:

--- a/virl2_client/models/lab.py
+++ b/virl2_client/models/lab.py
@@ -1345,6 +1345,7 @@ class Lab:
                 "cpu_usage": float(node_data.get("cpu_usage", 0)),
                 "disk_read": disk_read,
                 "disk_write": disk_write,
+                "times": node_data["times"],
             }
 
         for link_id, link_data in link_statistics.items():
@@ -1519,6 +1520,20 @@ class Lab:
         :returns: True if the lab is active, False otherwise
         """
         return self.state() == "STARTED"
+
+    @property
+    def uptime(self) -> int:
+        """
+        Return seconds since the most recent node start in this lab.
+
+        Smallest Node.started_time across the lab's nodes. Useful as
+        an abandoned-lab signal: a large value means the whole lab
+        has been up for a while with no recent node restarts.
+
+        :returns: Smallest Node.started_time, or 0 if any node in the
+            lab is not running (including the empty-lab case).
+        """
+        return min((n.started_time for n in self.nodes()), default=0)
 
     @check_stale
     def details(self) -> dict[str, str | list | int]:

--- a/virl2_client/models/node.py
+++ b/virl2_client/models/node.py
@@ -142,10 +142,11 @@ class Node:
         self._last_sync_l3_address_time = 0.0
         self._last_sync_operational_time = 0.0
 
-        self.statistics: dict[str, int | float] = {
+        self.statistics: dict[str, int | float | dict[str, int]] = {
             "cpu_usage": 0,
             "disk_read": 0,
             "disk_write": 0,
+            "times": {},
         }
 
     def __str__(self) -> str:
@@ -779,6 +780,53 @@ class Node:
         """
         self._lab.sync_statistics_if_outdated()
         return round(self.statistics["disk_write"] / 1048576)
+
+    @property
+    def times(self) -> dict[str, int]:
+        """
+        Return a copy of the per-state time markers for this node.
+
+        The controller reports STARTED and BOOTED as seconds since the
+        node last entered that state (smaller = more recent), and uses
+        0 to mean the node has not reached that state. QUEUED follows
+        a different convention (time spent in the queue).
+
+        :returns: Mapping of state name (QUEUED/STARTED/BOOTED) to the
+            value reported by the controller, empty before the first
+            simulation_stats sync.
+        """
+        self._lab.sync_statistics_if_outdated()
+        return self.statistics.get("times") or {}
+
+    @property
+    def boot_time(self) -> int:
+        """
+        Return seconds since this node last entered the BOOTED state.
+
+        :returns: The BOOTED time marker, or 0 if the node has not
+            reached BOOTED yet.
+        """
+        return self.times.get("BOOTED") or 0
+
+    @property
+    def started_time(self) -> int:
+        """
+        Return seconds since this node last entered the STARTED state.
+
+        :returns: The STARTED time marker, or 0 if the node has not
+            started yet.
+        """
+        return self.times.get("STARTED") or 0
+
+    @property
+    def queued_time(self) -> int:
+        """
+        Return the time this node has spent in the QUEUED state.
+
+        :returns: The QUEUED time marker, or 0 if the node was never
+            queued.
+        """
+        return self.times.get("QUEUED") or 0
 
     @locked
     def get_interface_by_label(self, label: str) -> Interface:


### PR DESCRIPTION
The Python Client Library was discarding the `times` block from `/labs/{id}/simulation_stats`, so callers had no way to ask "how long has this node been booted?" -- see CiscoDevNet/virl2-client#87.

Changes:
* Lab.sync_statistics now stores the controller's `times` dict alongside cpu_usage / disk_read / disk_write.
* Node gains `times`, `boot_time`, `started_time`, `queued_time` properties. The convenience properties return 0 when the node has not reached that state, matching the controller's own convention.
* Lab gains `uptime`: smallest non-zero STARTED marker across all nodes, useful as an abandoned-lab signal. Returns 0 when no node has started.
* Drive-by: keep the defensive `_get_element_from_data` reads for `cpu_usage` / `block0_*` so partial payloads from external connectors, unmanaged switches, and queued nodes (which only carry `times` + `is_running`) don't blow up sync_statistics on v2.9 / v2.10 servers either.

Tests cover the new properties, the partial-payload case, and the uptime aggregation.