### PR TITLE
CMLDEV-1127: Introduce STARTING node state for nodes pending full activation

### DIFF
--- a/virl2_client/models/node.py
+++ b/virl2_client/models/node.py
@@ -1208,7 +1208,7 @@ class Node:
 
         :returns: True if the node is in an active state, False otherwise.
         """
-        active_states = {"STARTED", "QUEUED", "BOOTED"}
+        active_states = {"STARTING", "STARTED", "QUEUED", "BOOTED"}
         return self.state in active_states
 
     def is_booted(self) -> bool:


### PR DESCRIPTION
#### CMLDEV-1127: Introduce STARTING node state for nodes pending full activation

###### Summary
• Adds `STARTING` to the set of states considered “active” in `Node.is_active()`, so nodes waiting for full activation match server semantics and callers that filter on is_active().
• Single-commit change on top of the shared ancestor with `dev`; no API or dependency churn.
###### Changes
• Models: `virl2_client/models/node.py` (virl2_client/models/node.py) — `active_states` now `{"STARTING", "STARTED", "QUEUED", "BOOTED"}` for `is_active()`.