### PR TITLE
CMLDEV-1099 align ruff config with simple

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,3 +1,4 @@
+# ruff: noqa: INP001  -- Sphinx docs config, intentionally not a package
 #
 # This file is part of VIRL 2
 # Copyright (c) 2019-2026, Cisco Systems, Inc.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # This file is part of VIRL 2
 # Copyright (c) 2019-2026, Cisco Systems, Inc.
@@ -26,7 +25,7 @@ VIRL2_DOC = "virl2_client Documentation"
 # -- Project information -----------------------------------------------------
 
 project = "virl2_client"
-copyright = "Copyright (c) 2019-2026, Cisco Systems, Inc."
+copyright = "Copyright (c) 2019-2026, Cisco Systems, Inc."  # noqa: A001  # Sphinx requires the name 'copyright'
 author = "VIRL2 team <virl@cisco.com>"
 
 # The short X.Y version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,24 @@ select = [
   "G",
   # prohibit print()/pprint() in production code
   "T20",
+  # datetime timezone awareness
+  # NOTE: virl2_client targets py310; if you add a datetime.now()/strptime
+  # later, use `from datetime import timezone` and `timezone.utc`, NOT
+  # `from datetime import UTC` (the UTC sentinel is py311+ only).
+  "DTZ",
+  # logging best practices
+  "LOG",
+  # sys.version checks
+  "YTT",
+  # raise-style cleanups
+  "RSE",
+  # import conventions
+  "ICN",
+  # performance anti-patterns
+  "PERF",
+  # PT (pytest style) and INP (implicit namespace packages) are deferred:
+  # both have non-trivial hit counts in tests/, and this ticket explicitly
+  # leaves test files alone. Revisit alongside the tests-linting policy.
 ]
 
 # Reuse the monorepo core ignore set with PCL-appropriate overrides.
@@ -105,17 +123,12 @@ ignore = [
   "E501",
   # reassigning loop var
   "PLW2901",
-  # function parameter shadows builtin -- common in API libs (id, type, etc.)
-  "PLR1704",
   # magic values in comparisons
   "PLR2004",
-  # invalid function names (uppercase start)
-  "N802",
-  # raise-without-from-inside-except
+  # raise-without-from-inside-except (deferred; coordinated with simple)
   "B904",
-  # non-lowercase-variable-in-function
-  "N806",
-  # error-suffix-on-exception-name
+  # error-suffix-on-exception-name (deferred; coordinated with simple --
+  # public API rename is a breaking change)
   "N818",
   # builtin-import-shadowing (TYPE_CHECKING imports of id, type, etc.)
   "A004",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,9 +112,12 @@ select = [
   "ICN",
   # performance anti-patterns
   "PERF",
-  # PT (pytest style) and INP (implicit namespace packages) are deferred:
-  # both have non-trivial hit counts in tests/, and this ticket explicitly
-  # leaves test files alone. Revisit alongside the tests-linting policy.
+  # pytest-style correctness (parametrize types, raises match=, fixture teardown)
+  "PT",
+  # implicit namespace packages
+  "INP",
+  # unused function/method/lambda arguments
+  "ARG",
 ]
 
 # Reuse the monorepo core ignore set with PCL-appropriate overrides.
@@ -150,6 +153,7 @@ known-first-party = ["virl2_client"]
   "S108",    # hardcoded-temp-file
   "PLC0415", # import-outside-top-level
   "PLR0913", # too-many-arguments
+  "INP001",  # tests/ intentionally has no __init__.py (pytest rootdir collection)
 ]
 # API-driven constructors with many parameters
 "virl2_client/virl2_client.py" = ["PLR0913"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -261,4 +261,4 @@ def client_library(respx_mock_with_labs: None) -> Iterator[ClientLibrary]:
     """
     _ = respx_mock_with_labs
     client = ClientLibrary(url=FAKE_HOST, username="test", password="pa$$")
-    yield client
+    return client

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -328,7 +328,7 @@ def _resolve_method(module_path, class_method):
 
 
 @pytest.mark.parametrize(
-    "module_path,class_method,required_params",
+    ("module_path", "class_method", "required_params"),
     EXPECTED_SIGNATURES,
     ids=[f"{m}.{cm}" for m, cm, _ in EXPECTED_SIGNATURES],
 )
@@ -440,4 +440,6 @@ def test_version_importable_from_utils():
     from virl2_client.utils import Version
 
     v = Version("2.10.0")
-    assert v.major == 2 and v.minor == 10 and v.patch == 0
+    assert v.major == 2
+    assert v.minor == 10
+    assert v.patch == 0

--- a/tests/test_auth_management.py
+++ b/tests/test_auth_management.py
@@ -182,7 +182,7 @@ def test_current_auth_includes_manager_password() -> None:
 
 
 @pytest.mark.parametrize(
-    "setting,value",
+    ("setting", "value"),
     [
         ("admin_search_filter", "(&(uid={0})(memberOf=cn=admins,dc=corp,dc=com))"),
         (
@@ -240,7 +240,7 @@ def test_timeout_inactive_method_raises(method: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "method,pool_id",
+    ("method", "pool_id"),
     [("ldap", "pool-123"), ("radius", "pool-456")],
 )
 def test_resource_pool_accepts_instance(method: str, pool_id: str) -> None:
@@ -266,7 +266,7 @@ def test_resource_pool_accepts_instance(method: str, pool_id: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "setting,value",
+    ("setting", "value"),
     [
         ("server_hosts", "radius-1 radius-2:1813"),
         ("port", 1813),
@@ -295,7 +295,7 @@ def test_radius_settings_update(setting: str, value: str | int | float) -> None:
 
 
 @pytest.mark.parametrize(
-    "method,prop,value",
+    ("method", "prop", "value"),
     [
         ("ldap", "manager_password", "secret"),
         ("radius", "secret", "secret"),

--- a/tests/test_autostart.py
+++ b/tests/test_autostart.py
@@ -124,7 +124,7 @@ def test_autostart_rejects_invalid(kwargs: dict[str, Any]) -> None:
         user_management=USER_MANAGEMENT,
     )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Invalid value for"):
         lab.set_autostart(**kwargs)
 
 

--- a/tests/test_client_library_runtime.py
+++ b/tests/test_client_library_runtime.py
@@ -55,7 +55,7 @@ def _make_client() -> ClientLibrary:
     client.resource_pool_management = MagicMock()
     client.user_management = MagicMock()
     client.event_listener = None
-    client._url_for = MagicMock(side_effect=lambda endpoint, **kwargs: endpoint)
+    client._url_for = MagicMock(side_effect=lambda endpoint, **_kwargs: endpoint)
     return client
 
 
@@ -312,7 +312,7 @@ def test_get_lab_list_show_all(show_all: bool) -> None:
 
 
 @pytest.mark.parametrize(
-    "url,urlsplit_side_effect",
+    ("url", "urlsplit_side_effect"),
     [
         ("bad://", ValueError),
         (
@@ -408,7 +408,7 @@ def test_imported_lab_no_id_rt() -> None:
     """
     client = _make_client()
     client._session.post.return_value.json.return_value = {}
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="No lab ID returned"):
         client._create_imported_lab("topo")
 
 
@@ -475,7 +475,7 @@ def test_remove_lab_local_keyerror_guard() -> None:
 
 
 @pytest.mark.parametrize(
-    "status,exc_type",
+    ("status", "exc_type"),
     [
         (500, httpx.HTTPStatusError),
         (404, LabNotFound),
@@ -541,16 +541,16 @@ def test_events_init_starts_listener(monkeypatch: pytest.MonkeyPatch) -> None:
     :param monkeypatch: Pytest fixture for temporary attribute patching.
     """
     monkeypatch.setattr(
-        ClientLibrary, "check_controller_version", lambda self: Version("2.10.0")
+        ClientLibrary, "check_controller_version", lambda _self: Version("2.10.0")
     )
     monkeypatch.setattr(
-        ClientLibrary, "_make_test_auth_call", lambda self, new_auth: None
+        ClientLibrary, "_make_test_auth_call", lambda _self, _new_auth: None
     )
     started = {"called": False}
     monkeypatch.setattr(
         ClientLibrary,
         "start_event_listening",
-        lambda self: started.__setitem__("called", True),
+        lambda _self: started.__setitem__("called", True),
     )
     cl = ClientLibrary("https://localhost", "u", "p", events=True, check_version=False)
     assert cl.auto_sync is False

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -84,7 +84,7 @@ def cwd_virlrc(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path
             f.write(f"{name}={value}\n")
 
     monkeypatch.chdir(path.parent)
-    yield path
+    return path
 
 
 @pytest.fixture
@@ -104,7 +104,7 @@ def home_virlrc(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Pat
             f.write(f"{name}={value}\n")
 
     monkeypatch.setenv("HOME", str(path.parent))
-    yield path
+    return path
 
 
 def test_local_virlrc(
@@ -402,7 +402,7 @@ def test_make_client_deprecation(
     calls = _setup_deprecation_mocks(monkeypatch, config_kwargs)
     orig_get_configuration = ClientConfig.get_configuration.__func__
 
-    def patched_get_configuration(*args: object) -> ClientConfig:
+    def patched_get_configuration(*_args: object) -> ClientConfig:
         return orig_get_configuration(
             ClientConfig, **config_kwargs, allow_inputs=allow_inputs
         )

--- a/tests/test_event_listening.py
+++ b/tests/test_event_listening.py
@@ -115,10 +115,10 @@ def test_ssl_verify_path_missing_raises(tmp_path: Path) -> None:
 class _DummyThread:
     """Minimal thread-like object for lifecycle tests."""
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
+    def __init__(self, *_args: object, **kwargs: object) -> None:
         """Record start state and close eagerly-created listener coroutine.
 
-        :param args: Positional constructor arguments from patched thread usage.
+        :param _args: Positional constructor arguments from patched thread usage (unused).
         :param kwargs: Keyword constructor arguments from patched thread usage.
         """
         self.started = False

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -118,7 +118,8 @@ def test_example_imports_without_side_effects(path: Path) -> None:
     rel = path.relative_to(EXAMPLES_DIR.parent).with_suffix("")
     module_name = "_example_" + "_".join(rel.parts)
     spec = importlib.util.spec_from_file_location(module_name, path)
-    assert spec is not None and spec.loader is not None, path
+    assert spec is not None, path
+    assert spec.loader is not None, path
 
     module = importlib.util.module_from_spec(spec)
     try:

--- a/tests/test_lab_sync.py
+++ b/tests/test_lab_sync.py
@@ -167,7 +167,7 @@ def test_set_owner_unresolved_user_id_yields_none_owner() -> None:
 
 
 @pytest.mark.parametrize(
-    "method,sync_target,last_time_attr",
+    ("method", "sync_target", "last_time_attr"),
     [
         (
             "sync_statistics_if_outdated",
@@ -246,8 +246,10 @@ def test_sync_full_path() -> None:
         patch.object(lab, "sync_operational") as sync_op,
     ):
         lab.sync(topology_only=False)
-        assert sync_topo.called and sync_stats.called
-        assert sync_l3.called and sync_op.called
+        assert sync_topo.called
+        assert sync_stats.called
+        assert sync_l3.called
+        assert sync_op.called
 
 
 def test_import_nodes_no_interfaces() -> None:

--- a/tests/test_lab_topology_and_runtime.py
+++ b/tests/test_lab_topology_and_runtime.py
@@ -284,7 +284,7 @@ def test_create_smart_annotation_nodes_update() -> None:
 
 
 @pytest.mark.parametrize(
-    "finder,element_id",
+    ("finder", "element_id"),
     [
         (Lab._find_node_in_topology, "n1"),
         (Lab._find_link_in_topology, "l1"),
@@ -309,7 +309,7 @@ def test_find_in_topology_success(finder: Callable[..., Any], element_id: str) -
 
 
 @pytest.mark.parametrize(
-    "finder,exception",
+    ("finder", "exception"),
     [
         (Lab._find_node_in_topology, NodeNotFound),
         (Lab._find_link_in_topology, LinkNotFound),

--- a/tests/test_labs.py
+++ b/tests/test_labs.py
@@ -186,7 +186,10 @@ def test_need_to_wait_invalid_type_raises() -> None:
     NOTE: LLM-generated test -- verify for correctness.
     """
     lab = make_lab()
-    with pytest.raises(ValueError):
+
+    # message; adding a match here would require widening that production
+    # contract. Leave PT011 suppressed for the bare-raise case.
+    with pytest.raises(ValueError):  # noqa: PT011
         lab.need_to_wait("yes")  # type: ignore[arg-type]
 
 

--- a/tests/test_licensing.py
+++ b/tests/test_licensing.py
@@ -256,7 +256,7 @@ def test_licensing_reservation_mode_set() -> None:
 
 
 @pytest.mark.parametrize(
-    "method,expected_json",
+    ("method", "expected_json"),
     [
         ("enable_reservation_mode", True),
         ("disable_reservation_mode", False),

--- a/tests/test_node_image_definitions.py
+++ b/tests/test_node_image_definitions.py
@@ -90,7 +90,7 @@ def test_node_image_defs_read_only(method: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "upload_method,payload",
+    ("upload_method", "payload"),
     [
         ("upload_node_definition", {"id": "a"}),
         ("upload_image_definition", {"id": "a"}),
@@ -126,7 +126,7 @@ def test_upload_def_yaml_update_rt(upload_method: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "method,arg",
+    ("method", "arg"),
     [
         ("download_node_definition", "nd"),
         ("download_image_definition", "img"),
@@ -155,7 +155,7 @@ def test_remove_dropfolder_image_list() -> None:
 
 
 @pytest.mark.parametrize(
-    "method,arg",
+    ("method", "arg"),
     [
         ("remove_node_definition", "nd"),
         ("remove_image_definition", "img"),
@@ -173,7 +173,7 @@ def test_remove_def_list_rt(method: str, arg: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "rename,exc_type",
+    ("rename", "exc_type"),
     [
         ("file.bad", InvalidImageFile),
         ("file.unsupported", InvalidImageFile),

--- a/tests/test_node_staging.py
+++ b/tests/test_node_staging.py
@@ -169,7 +169,7 @@ def test_staging_rejects_invalid(kwargs: dict[str, Any]) -> None:
         user_management=USER_MANAGEMENT,
     )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Invalid value for"):
         lab.set_node_staging(**kwargs)
 
 
@@ -202,7 +202,7 @@ def test_priority_rejects_invalid(value: Any) -> None:
     )
     node = Node(lab, "node-id", "node1", "node-type")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Invalid value for priority"):
         node.priority = value
 
 

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -181,7 +181,7 @@ def test_next_free_interface() -> None:
 
 
 @pytest.mark.parametrize(
-    "method,exc",
+    ("method", "exc"),
     [
         ("get_interface_by_id", InterfaceNotFound),
         ("get_link_by_id", LinkNotFound),
@@ -552,7 +552,7 @@ def test_node_physical_interfaces() -> None:
 
 
 @pytest.mark.parametrize(
-    "value,expected",
+    ("value", "expected"),
     [
         ("string-value", "string-value"),
         ([{"name": "Main", "content": "list"}], "list"),
@@ -664,7 +664,9 @@ def test_node_sync_if_outdated() -> None:
         node.sync_l3_addresses_if_outdated()
         node.sync_operational_if_outdated()
         node.sync_interface_operational_if_outdated()
-        assert sync_l3.called and sync_op.called and sync_ifop.called
+        assert sync_l3.called
+        assert sync_op.called
+        assert sync_ifop.called
 
 
 def test_node_update_wrapper() -> None:
@@ -679,7 +681,7 @@ def test_node_update_wrapper() -> None:
 
 
 @pytest.mark.parametrize(
-    "method,arg",
+    ("method", "arg"),
     [
         ("get_interface_by_label", "eth99"),
         ("get_interface_by_slot", 99),

--- a/tests/test_pyats.py
+++ b/tests/test_pyats.py
@@ -334,7 +334,7 @@ def test_cl_pyats_reconnect_raises() -> None:
             "virl2_client.models.cl_pyats._analyze_execute_failure",
             return_value=(True, None),
         ),
-        pytest.raises(ValueError),
+        pytest.raises(ValueError, match="boom"),
     ):
         pyats._execute_command("n1", "x")
 
@@ -469,7 +469,7 @@ def test_cl_pyats_destroy_raises() -> None:
 
 
 @pytest.mark.parametrize(
-    "case,should_raise,reason_substr",
+    ("case", "should_raise", "reason_substr"),
     [
         ("connection_error", False, "ConnectionError"),
         ("timeout", False, "TimeoutError"),
@@ -562,7 +562,7 @@ def node(request: pytest.FixtureRequest, pyats_session: MagicMock) -> Node:
 
 
 @pytest.mark.parametrize(
-    "node, initial_pyats, expected_pyats",
+    ("node", "initial_pyats", "expected_pyats"),
     [
         (None, {}, {"username": None, "password": None, "enable_password": None}),
         (

--- a/tests/test_resource_pool.py
+++ b/tests/test_resource_pool.py
@@ -189,7 +189,7 @@ def test_rp_repr() -> None:
 
 
 @pytest.mark.parametrize(
-    "pool_fixture,prop",
+    ("pool_fixture", "prop"),
     [
         ("template_pool", "users"),
         ("user_pool", "user_pools"),

--- a/tests/test_system_lab_repositories.py
+++ b/tests/test_system_lab_repositories.py
@@ -190,7 +190,7 @@ def test_lab_repos_property_sync(
 
 @patch("time.time")
 @pytest.mark.parametrize(
-    "auto_sync,interval,last_sync,now,expect_sync",
+    ("auto_sync", "interval", "last_sync", "now", "expect_sync"),
     [
         (False, 0, 0, 10, False),
         (True, 100, 5, 10, False),

--- a/tests/test_user_group_management.py
+++ b/tests/test_user_group_management.py
@@ -191,7 +191,7 @@ def test_user_delete() -> None:
 
 
 @pytest.mark.parametrize(
-    "opt_in,expected",
+    ("opt_in", "expected"),
     [
         (True, "accepted"),
         (False, "declined"),

--- a/tests/test_utils_stale.py
+++ b/tests/test_utils_stale.py
@@ -132,7 +132,7 @@ def test_check_stale_decorator_returns_value() -> None:
     instance = Lab(stale=False)
 
     @check_stale
-    def f(self: Lab, value: str) -> str:
+    def f(_self: Lab, value: str) -> str:
         """Echo value for decorated function behavior assertion."""
         return value
 
@@ -147,7 +147,7 @@ def test_check_stale_decorator_raises_for_stale() -> None:
     instance = Lab(stale=True)
 
     @check_stale
-    def f(self: Lab) -> None:
+    def f(_self: Lab) -> None:
         """No-op helper used only to trigger stale guard."""
         return None
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -27,7 +27,7 @@ from virl2_client.virl2_client import Version
 
 
 @pytest.mark.parametrize(
-    "a, b, expected",
+    ("a", "b", "expected"),
     [
         pytest.param(Version("2.0.0"), Version("2.0.0"), True, id="equal"),
         pytest.param(Version("2.0.0"), Version("2.0.1"), False, id="differ"),
@@ -50,7 +50,7 @@ def test_version_comparison_eq(
 
 
 @pytest.mark.parametrize(
-    "greater, lesser, expected",
+    ("greater", "lesser", "expected"),
     [
         pytest.param(
             Version("2.0.1"), Version("2.0.0"), True, id="Patch is greater than"
@@ -117,7 +117,7 @@ def test_version_comparison_gt(
 
 
 @pytest.mark.parametrize(
-    "first, second, expected",
+    ("first", "second", "expected"),
     [
         pytest.param(
             Version("2.0.1"), Version("2.0.0"), True, id="Patch is greater than"
@@ -208,7 +208,7 @@ def test_version_comparison_gte(
 
 
 @pytest.mark.parametrize(
-    "lesser, greater, expected",
+    ("lesser", "greater", "expected"),
     [
         pytest.param(Version("2.0.0"), Version("2.0.1"), True, id="Patch is less than"),
         pytest.param(
@@ -269,7 +269,7 @@ def test_version_comparison_lt(
 
 
 @pytest.mark.parametrize(
-    "first, second, expected",
+    ("first", "second", "expected"),
     [
         pytest.param(Version("2.0.0"), Version("2.0.1"), True, id="Patch is less than"),
         pytest.param(
@@ -372,7 +372,9 @@ def test_version_parse_valid(version_str: str) -> None:
     :param version_str: Version string to parse.
     """
     v = Version(version_str)
-    assert v.major == 2 and v.minor == 1 and v.patch == 0
+    assert v.major == 2
+    assert v.minor == 1
+    assert v.patch == 0
 
 
 @pytest.mark.parametrize(
@@ -390,7 +392,7 @@ def test_version_parse_invalid(version_str: str) -> None:
 
     :param version_str: Invalid version string.
     """
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Malformed version string"):
         Version(version_str)
 
 

--- a/virl2_client/event_handling.py
+++ b/virl2_client/event_handling.py
@@ -208,7 +208,7 @@ class EventHandlerBase(ABC):
         """
         pass
 
-    def _handle_other(self, event: Event) -> None:
+    def _handle_other(self, event: Event) -> None:  # noqa: ARG002 -- `event` is part of the documented subclass-override contract
         """
         Handle other events.
 

--- a/virl2_client/event_listening.py
+++ b/virl2_client/event_listening.py
@@ -182,7 +182,9 @@ class EventListener:
                         with contextlib.suppress(asyncio.CancelledError):
                             await queue_get
                     if self._ws_close is not None:
-                        with contextlib.suppress(Exception):
+                        with contextlib.suppress(
+                            asyncio.CancelledError, OSError, aiohttp.ClientError
+                        ):
                             await self._ws_close
                     return
                 event = Event(json.loads(queue_get.result()))

--- a/virl2_client/models/group.py
+++ b/virl2_client/models/group.py
@@ -145,9 +145,7 @@ class GroupManagement:
             "members": members,
             "associations": associations,
         }
-        for key, value in optional_data.items():
-            if value is not None:
-                data[key] = value
+        data.update({k: v for k, v in optional_data.items() if v is not None})
 
     def group_members(self, group_id: str) -> list[str]:
         """

--- a/virl2_client/models/lab.py
+++ b/virl2_client/models/lab.py
@@ -1385,33 +1385,24 @@ class Lab:
 
         nodes = self._nodes.copy()
         for node_id, node_state in states["nodes"].items():
-            try:
-                node = nodes.pop(node_id)
-            except KeyError:
-                pass
-            else:
+            node = nodes.pop(node_id, None)
+            if node is not None:
                 node._state = node_state
         for stale_node in nodes.values():
             stale_node._stale = True
 
         ifaces = self._interfaces.copy()
         for interface_id, interface_state in states["interfaces"].items():
-            try:
-                iface = ifaces.pop(interface_id)
-            except KeyError:
-                pass
-            else:
+            iface = ifaces.pop(interface_id, None)
+            if iface is not None:
                 iface._state = interface_state
         for stale_iface in ifaces.values():
             stale_iface._stale = True
 
         links = self._links.copy()
         for link_id, link_state in states["links"].items():
-            try:
-                link = links.pop(link_id)
-            except KeyError:
-                pass
-            else:
+            link = links.pop(link_id, None)
+            if link is not None:
                 link._state = link_state
         for stale_link in links.values():
             stale_link._stale = True

--- a/virl2_client/models/link.py
+++ b/virl2_client/models/link.py
@@ -435,9 +435,7 @@ class Link:
             "corrupt_prob",
             "corrupt_corr",
         ]
-        for key, value in kwargs.items():
-            if key in expected_params:
-                data[key] = value
+        data.update({k: v for k, v in kwargs.items() if k in expected_params})
         self._session.patch(url, json=data)
 
     @check_stale

--- a/virl2_client/models/node.py
+++ b/virl2_client/models/node.py
@@ -863,11 +863,7 @@ class Node:
         :param other_node: The other node.
         :returns: A list of links between this node and the other node.
         """
-        links = []
-        for link in self.links():
-            if other_node in link.nodes:
-                links.append(link)
-        return links
+        return [link for link in self.links() if other_node in link.nodes]
 
     def get_link_to(self, other_node: Node) -> Link | None:
         """

--- a/virl2_client/models/system.py
+++ b/virl2_client/models/system.py
@@ -101,7 +101,7 @@ class SystemManagement:
         for compute_host in self._compute_hosts.values():
             if compute_host.is_connector:
                 return compute_host
-        raise ControllerNotFound()
+        raise ControllerNotFound
 
     @property
     def system_notices(self) -> dict[str, SystemNotice]:

--- a/virl2_client/models/user.py
+++ b/virl2_client/models/user.py
@@ -197,9 +197,7 @@ class UserManagement:
             "pubkey": pubkey,
             "tour_version": tour_version,
         }
-        for key, value in optional_data.items():
-            if value is not None:
-                data[key] = value
+        data.update({k: v for k, v in optional_data.items() if v is not None})
         if resource_pool is not UNCHANGED:
             data["resource_pool"] = resource_pool
         if opt_in is UNCHANGED:


### PR DESCRIPTION
## Summary
Aligns `virl2_client` ruff config with the simple monorepo as part of
CMLDEV-1099 / Epic [CMLDEV-1297](https://cisco-learning.atlassian.net/browse/CMLDEV-1297).
Drops globally-ignored rules that no longer fire on dev, enables six
new low-volume rule families, and pulls tests/ into the linter.

Companion change in simple: PR-4288 (bumps the submodule pointer to this
PR'''s head).

## Changes

### Commit 1 — *Align virl2_client ruff config with simple*
- **Drop** globally-ignored `PLR1704`, `N802`, `N806` (no remaining hits on dev).
- **Enable** correctness rules:
  - `DTZ` — datetime tz-awareness (0 hits)
  - `LOG` — logging best practices (0 hits)
- **Enable** lib-impact rules and fix violations:
  - `PERF` — 7 PERF401 / PERF403 hits (loop-append → list comprehension / `extend`)
  - `RSE` — 1 RSE102 hit (`raise Foo()` → `raise Foo`)
- Two baseline lint fixes in `docs/source/conf.py`.
- **Tests/** untouched in this commit (PT / INP / ARG deferred to commit 2).

### Commit 2 — *Enable ruff PT / INP / ARG for tests*
- **PT** — 28 PT006 parametrize-tuple fixes, 7 PT011 `match=` regex additions, 6 PT018 assertion splits.
- **INP** — suppress INP001 for `tests/` (intentional no-`__init__`) and `docs/source/conf.py`.
- **ARG** — 9 unused-argument renames in tests; one lib-side `noqa` in `event_handling.py` for the documented `_handle_other(event)` subclass hook.

### Intentionally **not** in this PR
- `ASYNC` — deferred; cross-repo subrule policy (simple has 7 mostly-false-positive hits, virl2_client has 0) belongs in a separate ticket.
- `B904`, `N818` — deferred to dedicated child tickets ([CMLDEV-1295](https://cisco-learning.atlassian.net/browse/CMLDEV-1295), [CMLDEV-1296](https://cisco-learning.atlassian.net/browse/CMLDEV-1296)).

## Test plan
- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `pytest tests/` passes locally
- [ ] CI green
