### PR TITLE
CMLDEV-1266: Fix virl2_client and server endpoint drift

### DIFF
--- a/tests/test_client_library_runtime.py
+++ b/tests/test_client_library_runtime.py
@@ -153,7 +153,7 @@ def test_sample_labs() -> None:
         client._session.get.return_value.json.return_value = {"sample": {}}
         assert client.get_sample_labs() == {"sample": {}}
         client._session.put.return_value.json.return_value = "id-1"
-        client.import_sample_lab("sample-1")
+        client.import_sample_lab("id-1")  # need to check the ID is correct
         join_lab.assert_called_with("id-1")
 
 

--- a/tests/test_pcap.py
+++ b/tests/test_pcap.py
@@ -86,7 +86,7 @@ def test_pcap_packet_url_has_packet_id(link: Link) -> None:
     """
     url = link._url_for("pcap_packet", packet_id="42")
 
-    assert url == "pcap/test-link/packets/42"
+    assert url == "pcap/test-link/packet/42"
     assert "api/v0" not in url
     assert "//" not in url
 

--- a/virl2_client/models/lab.py
+++ b/virl2_client/models/lab.py
@@ -1585,7 +1585,7 @@ class Lab:
 
         """
         url = self._url_for("bootstrap")
-        self._session.get(url)
+        self._session.put(url)
         # sync to get the updated configs
         self.sync_topology_if_outdated()
 

--- a/virl2_client/models/licensing.py
+++ b/virl2_client/models/licensing.py
@@ -217,7 +217,7 @@ class Licensing:
     def update_features(self, features: list[dict[str, int]]) -> None:
         """Update licensing feature's explicit count in reservation mode.
 
-        :param features: Feature names to counts, or list of such mappings.
+        :param features: list of feature names to count mappings.
         """
         url = self._url_for("features")
         self._session.patch(url, json=features)

--- a/virl2_client/models/licensing.py
+++ b/virl2_client/models/licensing.py
@@ -214,7 +214,7 @@ class Licensing:
         )
         return self.status().get("features")
 
-    def update_features(self, features: dict[str, int] | list[dict[str, int]]) -> None:
+    def update_features(self, features: list[dict[str, int]]) -> None:
         """Update licensing feature's explicit count in reservation mode.
 
         :param features: Feature names to counts, or list of such mappings.

--- a/virl2_client/models/link.py
+++ b/virl2_client/models/link.py
@@ -51,7 +51,7 @@ class Link:
         "capture_status": "{lab}/links/{id}/capture/status",
         "pcap_file": "pcap/{id}",
         "pcap_packets": "pcap/{id}/packets",
-        "pcap_packet": "pcap/{id}/packets/{packet_id}",
+        "pcap_packet": "pcap/{id}/packet/{packet_id}",
     }
 
     def __init__(

--- a/virl2_client/models/link.py
+++ b/virl2_client/models/link.py
@@ -43,7 +43,6 @@ class Link:
     _URL_TEMPLATES: ClassVar[dict[str, str]] = {
         "link": "{lab}/links/{id}",
         "check_if_converged": "{lab}/links/{id}/check_if_converged",
-        "state": "{lab}/links/{id}/state",
         "start": "{lab}/links/{id}/state/start",
         "stop": "{lab}/links/{id}/state/stop",
         "condition": "{lab}/links/{id}/condition",

--- a/virl2_client/virl2_client.py
+++ b/virl2_client/virl2_client.py
@@ -604,15 +604,15 @@ class ClientLibrary:
         return self._session.get(url).json()
 
     @locked
-    def import_sample_lab(self, title: str) -> Lab:
+    def import_sample_lab(self, sample_lab_id: str) -> Lab:
         """
         Import a built-in sample lab.
 
-        :param title: The sample lab name.
+        :param sample_lab_id: The sample lab ID.
         :returns: The imported Lab instance.
         """
 
-        url = self._url_for("sample_lab", sample_lab_id=title)
+        url = self._url_for("sample_lab", sample_lab_id=sample_lab_id)
         lab_id = self._session.put(url).json()
         return self.join_existing_lab(lab_id)
 

--- a/virl2_client/virl2_client.py
+++ b/virl2_client/virl2_client.py
@@ -237,7 +237,7 @@ class ClientLibrary:
         "import": "import",
         "import_1x": "import/virl-1x",
         "sample_labs": "sample/labs",
-        "sample_lab": "sample/labs/{lab_title}",
+        "sample_lab": "sample/labs/{sample_lab_id}",
         "labs": "labs",
         "lab": "labs/{lab_id}",
         "lab_topology": "labs/{lab_id}/topology",
@@ -612,7 +612,7 @@ class ClientLibrary:
         :returns: The imported Lab instance.
         """
 
-        url = self._url_for("sample_lab", lab_title=title)
+        url = self._url_for("sample_lab", sample_lab_id=title)
         lab_id = self._session.put(url).json()
         return self.join_existing_lab(lab_id)
 


### PR DESCRIPTION
- use PUT instead of GET for labs/{lab_id}/bootstrap API
- removed dict annotation for licensing:update_features
- removed "{lab}/links/{id}/state" from Link._URL_TEMPLATES