### PR TITLE
CMLDEV-1347: provide outcomes in lab bootstrap API

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,8 @@ addopts =
     --strict-markers
     --verbose
     --showlocals
+    # pyats[library] pulls libtmux transitively
+    -p no:libtmux
 
 # the below configuration lines are needed to for
 # code coverage reporting

--- a/tests/test_lab_lifecycle.py
+++ b/tests/test_lab_lifecycle.py
@@ -26,7 +26,7 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
-from tests.helpers import make_lab
+from helpers import make_lab
 from virl2_client.exceptions import LabNotFound, NodeNotFound
 
 
@@ -269,7 +269,7 @@ def test_lab_is_active() -> None:
 
 
 def test_lab_details() -> None:
-    """Details returns json from session.
+    """Details returns JSON from session.
 
     NOTE: LLM-generated test -- verify for correctness.
     """
@@ -300,16 +300,19 @@ def test_lab_sync_events() -> None:
 
 
 def test_lab_build_configurations() -> None:
-    """build_configurations calls sync_topology_if_outdated.
-
-    NOTE: LLM-generated test -- verify for correctness.
-    """
+    """build_configurations returns per-node results and calls sync_topology_if_outdated."""
     lab = make_lab()
+    expected_results = [
+        {"id": "n0", "label": "R1", "result": "generated", "reason": None},
+        {"id": "n1", "label": "R2", "result": "skipped", "reason": "already configured"},
+    ]
+    lab._session.put.return_value.json.return_value = expected_results
     with patch.object(
         lab, "sync_topology_if_outdated", return_value=None
     ) as sync_topology:
-        lab.build_configurations()
+        results = lab.build_configurations()
         sync_topology.assert_called_once()
+    assert results == expected_results
 
 
 def test_lab_convergence_timeout() -> None:

--- a/tests/test_lab_lifecycle.py
+++ b/tests/test_lab_lifecycle.py
@@ -25,8 +25,8 @@ from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
-from helpers import make_lab
 
+from tests.helpers import make_lab
 from virl2_client.exceptions import LabNotFound, NodeNotFound
 
 
@@ -311,6 +311,7 @@ def test_lab_build_configurations() -> None:
             "reason": "already configured",
         },
     ]
+    lab._session.put.return_value.status_code = 200
     lab._session.put.return_value.json.return_value = expected_results
     with patch.object(
         lab, "sync_topology_if_outdated", return_value=None
@@ -318,6 +319,19 @@ def test_lab_build_configurations() -> None:
         results = lab.build_configurations()
         sync_topology.assert_called_once()
     assert results == expected_results
+
+
+def test_lab_build_configurations_pre_211_no_content() -> None:
+    """Pre-2.11 bootstrap returned 204 with no body; return an empty list."""
+    lab = make_lab()
+    lab._session.put.return_value.status_code = 204
+    with patch.object(
+        lab, "sync_topology_if_outdated", return_value=None
+    ) as sync_topology:
+        results = lab.build_configurations()
+        sync_topology.assert_called_once()
+    assert results == []
+    lab._session.put.return_value.json.assert_not_called()
 
 
 def test_lab_convergence_timeout() -> None:

--- a/tests/test_lab_lifecycle.py
+++ b/tests/test_lab_lifecycle.py
@@ -25,8 +25,8 @@ from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
-
 from helpers import make_lab
+
 from virl2_client.exceptions import LabNotFound, NodeNotFound
 
 

--- a/tests/test_lab_lifecycle.py
+++ b/tests/test_lab_lifecycle.py
@@ -304,7 +304,12 @@ def test_lab_build_configurations() -> None:
     lab = make_lab()
     expected_results = [
         {"id": "n0", "label": "R1", "result": "generated", "reason": None},
-        {"id": "n1", "label": "R2", "result": "skipped", "reason": "already configured"},
+        {
+            "id": "n1",
+            "label": "R2",
+            "result": "skipped",
+            "reason": "already configured",
+        },
     ]
     lab._session.put.return_value.json.return_value = expected_results
     with patch.object(

--- a/tests/test_lab_sync.py
+++ b/tests/test_lab_sync.py
@@ -22,148 +22,15 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-import httpx
 import pytest
 
-from tests.helpers import make_lab
+from helpers import make_lab
 from virl2_client.exceptions import (
     ElementAlreadyExists,
-    LabNotFound,
     SmartAnnotationNotFound,
 )
-
-
-def test_sync_topology_import_path() -> None:
-    """_sync_topology calls import_lab when not initialized.
-
-    NOTE: LLM-generated test -- verify for correctness.
-    """
-    lab = make_lab()
-    topology = {
-        "lab": {"title": "T", "description": "D", "notes": "N", "owner": None},
-        "nodes": [],
-        "links": [],
-        "annotations": [],
-        "smart_annotations": [],
-    }
-    lab._initialized = False
-    lab._session.get.return_value = MagicMock(json=MagicMock(return_value=topology))
-    with patch.object(lab, "import_lab") as import_lab:
-        lab._sync_topology()
-        import_lab.assert_called_once()
-        assert lab._initialized is True
-
-
-def test_sync_topology_update_path() -> None:
-    """_sync_topology calls update_lab when initialized.
-
-    NOTE: LLM-generated test -- verify for correctness.
-    """
-    lab = make_lab()
-    topology = {
-        "lab": {"title": "T", "description": "D", "notes": "N", "owner": None},
-        "nodes": [],
-        "links": [],
-        "annotations": [],
-        "smart_annotations": [],
-    }
-    lab._initialized = True
-    lab._session.get.return_value = MagicMock(json=MagicMock(return_value=topology))
-    with patch.object(lab, "update_lab") as update_lab_mock:
-        lab._sync_topology()
-        update_lab_mock.assert_called_once()
-
-
-def test_sync_topology_404() -> None:
-    """_sync_topology raises LabNotFound on 404 and marks stale.
-
-    NOTE: LLM-generated test -- verify for correctness.
-    """
-    lab = make_lab()
-    not_found = httpx.HTTPStatusError(
-        "404",
-        request=httpx.Request("GET", "https://x"),
-        response=httpx.Response(status_code=404, text="Lab not found: l1"),
-    )
-    lab._session.get.side_effect = not_found
-    with pytest.raises(LabNotFound):
-        lab._sync_topology()
-    assert lab._stale is True
-
-
-def test_sync_topology_500() -> None:
-    """_sync_topology raises HTTPStatusError on 500.
-
-    NOTE: LLM-generated test -- verify for correctness.
-    """
-    lab = make_lab()
-    generic = httpx.HTTPStatusError(
-        "500",
-        request=httpx.Request("GET", "https://x"),
-        response=httpx.Response(status_code=500, text="boom"),
-    )
-    lab._session.get.side_effect = generic
-    with pytest.raises(httpx.HTTPStatusError):
-        lab._sync_topology()
-
-
-def test_import_old_schema() -> None:
-    """_import_lab handles old schema path for created labs.
-
-    NOTE: LLM-generated test -- verify for correctness.
-    """
-    user_mgmt = MagicMock()
-    user_mgmt.get_username.return_value = "owner-1"
-    lab = make_lab(user_management=user_mgmt)
-    old_schema = {
-        "lab_title": "created",
-        "lab_description": "desc",
-        "lab_notes": "notes",
-        "owner": "u1",
-        "autostart": {"enabled": True, "priority": 1, "delay": 0},
-        "node_staging": {
-            "enabled": True,
-            "start_remaining": False,
-            "abort_on_failure": True,
-        },
-    }
-    lab._import_lab(old_schema, created=True)
-    assert lab.title == "created"
-    assert lab.owner == "owner-1"
-    assert lab.owner_id == "u1"
-    assert lab.autostart["enabled"] is True
-    assert lab.node_staging["enabled"] is True
-    user_mgmt.get_username.assert_called_once_with("u1")
-
-
-def test_set_owner_username_overrides_cache() -> None:
-    """Caller-supplied user_name wins and the cache is not consulted.
-
-    NOTE: LLM-generated test -- verify for correctness.
-    """
-    user_mgmt = MagicMock()
-    user_mgmt.get_username.return_value = "from-cache"
-    lab = make_lab(user_management=user_mgmt)
-    lab._set_owner(user_id="u1", user_name="from-response")
-    assert lab.owner == "from-response"
-    assert lab.owner_id == "u1"
-    user_mgmt.get_username.assert_not_called()
-
-
-def test_set_owner_unresolved_user_none() -> None:
-    """When only user_id is supplied and the cache misses, owner is None.
-
-    NOTE: LLM-generated test -- verify for correctness.
-    """
-    user_mgmt = MagicMock()
-    user_mgmt.get_username.return_value = None
-    lab = make_lab(user_management=user_mgmt)
-    lab._set_owner(user_id="missing")
-    assert lab.owner is None
-    assert lab.owner_id == "missing"
-    user_mgmt.get_username.assert_called_once_with("missing")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_lab_sync.py
+++ b/tests/test_lab_sync.py
@@ -25,8 +25,8 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pytest
-
 from helpers import make_lab
+
 from virl2_client.exceptions import (
     ElementAlreadyExists,
     SmartAnnotationNotFound,

--- a/tests/test_lab_sync.py
+++ b/tests/test_lab_sync.py
@@ -25,8 +25,8 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pytest
-from helpers import make_lab
 
+from tests.helpers import make_lab
 from virl2_client.exceptions import (
     ElementAlreadyExists,
     SmartAnnotationNotFound,

--- a/virl2_client/models/lab.py
+++ b/virl2_client/models/lab.py
@@ -1588,7 +1588,12 @@ class Lab:
         ``"failed"``), and an optional ``reason`` string.
         """
         url = self._url_for("bootstrap")
-        results: list[dict] = self._session.put(url).json()
+        response = self._session.put(url)
+        if response.status_code == 204:
+            # Pre-2.11 controllers returned 204 No Content with no body.
+            results: list[dict] = []
+        else:
+            results = response.json()
         # sync to get the updated configs
         self.sync_topology_if_outdated()
         return results

--- a/virl2_client/models/lab.py
+++ b/virl2_client/models/lab.py
@@ -1578,16 +1578,20 @@ class Lab:
         return changed
 
     @check_stale
-    def build_configurations(self) -> None:
+    def build_configurations(self) -> list[dict]:
         """
         Build basic configurations for all nodes in the lab that do not
         already have a configuration and support configuration building.
 
+        Returns a list of per-node bootstrap results, each containing
+        ``id``, ``label``, ``result`` (``"generated"``, ``"skipped"``, or
+        ``"failed"``), and an optional ``reason`` string.
         """
         url = self._url_for("bootstrap")
-        self._session.put(url)
+        results: list[dict] = self._session.put(url).json()
         # sync to get the updated configs
         self.sync_topology_if_outdated()
+        return results
 
     @check_stale
     @locked


### PR DESCRIPTION
- updated build_configuration function to use expose returned results
- deleted duplicated tests from tests/test_lab_sync.py (the same tests are present in test_lab_lifecycle.py)
- updated test_lab_build_configurations to verify returned values