### PR TITLE
CMLDEV-1295 Enable additional ruff rule families and apply mechanical fixes

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -21,7 +21,10 @@
 
 from __future__ import annotations
 
-import pytest
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pytest
 
 
 def pytest_addoption(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,8 @@ ignore = [
   "A004",
   # invalid-class-name -- intentional lowercase class (property_s)
   "N801",
+  # allow explicit pass in placeholder implementations
+  "PIE790",
 ]
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,14 +118,36 @@ select = [
   "INP",
   # unused function/method/lambda arguments
   "ARG",
+  # flake8-blind-except
+  "BLE",
+  # furbelow (syntax improvements)
+  "FURB",
+  # flake8-implicit-str-concat
+  "ISC",
+  # flake8-quotes
+  "Q",
+  # flake8-future-annotations
+  "FA",
+  # flake8-print
+  "T10",
+  # flake8-todos
+  "TD",
+  # auto-fixable issues
+  "FIX",
+  # pygrep-hooks
+  "PGH",
+  # type-checking imports
+  "TCH",
+  # flake8-pie
+  "PIE",
+  # flake8-return
+  "RET",
 ]
 
 # Reuse the monorepo core ignore set with PCL-appropriate overrides.
 ignore = [
   # line too long -- handled by formatter
   "E501",
-  # reassigning loop var
-  "PLW2901",
   # magic values in comparisons
   "PLR2004",
   # raise-without-from-inside-except (deferred; coordinated with simple)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -260,5 +260,4 @@ def client_library(respx_mock_with_labs: None) -> Iterator[ClientLibrary]:
     :yields: A ClientLibrary connected to FAKE_HOST with test credentials.
     """
     _ = respx_mock_with_labs
-    client = ClientLibrary(url=FAKE_HOST, username="test", password="pa$$")
-    return client
+    return ClientLibrary(url=FAKE_HOST, username="test", password="pa$$")

--- a/tests/test_client_init.py
+++ b/tests/test_client_init.py
@@ -21,12 +21,15 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from typing import TYPE_CHECKING
 
 import httpx
 import pytest
 
 from virl2_client.virl2_client import ClientLibrary, InitializationError
+
+if TYPE_CHECKING:
+    from unittest.mock import MagicMock
 
 FAKE_URL = "https://0.0.0.0/fake_url/"
 

--- a/tests/test_client_library.py
+++ b/tests/test_client_library.py
@@ -23,8 +23,7 @@ from __future__ import annotations
 
 import json
 import logging
-from collections.abc import Iterator
-from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -39,6 +38,10 @@ from virl2_client.virl2_client import (
     InitializationError,
     Version,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
 
 CURRENT_VERSION = ClientLibrary.VERSION.version_str
 FAKE_URL = "https://0.0.0.0/fake_url/"

--- a/tests/test_client_library_labs.py
+++ b/tests/test_client_library_labs.py
@@ -21,10 +21,10 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import pytest
-from respx import MockRouter
 
 from tests.helpers import RESOURCE_POOL_MANAGER, USER_MANAGEMENT, make_lab
 from virl2_client.exceptions import (
@@ -34,7 +34,11 @@ from virl2_client.exceptions import (
 )
 from virl2_client.models import Lab
 from virl2_client.models.authentication import make_session
-from virl2_client.virl2_client import ClientLibrary
+
+if TYPE_CHECKING:
+    from respx import MockRouter
+
+    from virl2_client.virl2_client import ClientLibrary
 
 
 def test_join_existing_lab(client_library: ClientLibrary) -> None:

--- a/tests/test_event_listening.py
+++ b/tests/test_event_listening.py
@@ -25,13 +25,15 @@ Tests are skipped when aiohttp is not installed via pytest.importorskip.
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncIterator
-from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
 
 try:
     import aiohttp
@@ -134,7 +136,7 @@ class _DummyThread:
 
     def join(self) -> None:
         """Provide thread-join compatibility for tests."""
-        return None
+        return
 
 
 def test_bool_reflects_listening_state() -> None:

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -21,15 +21,18 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
-from respx import MockRouter
 
 from tests.helpers import RESOURCE_POOL_MANAGER, USER_MANAGEMENT, make_lab
 from virl2_client.exceptions import InterfaceNotFound
 from virl2_client.models import Interface, Lab, Node
 from virl2_client.models.authentication import make_session
+
+if TYPE_CHECKING:
+    from respx import MockRouter
 
 
 def test_create_interface_raises_slot_missing() -> None:

--- a/tests/test_lab_topology_and_runtime.py
+++ b/tests/test_lab_topology_and_runtime.py
@@ -21,8 +21,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -37,6 +36,9 @@ from virl2_client.exceptions import (
     SmartAnnotationNotFound,
 )
 from virl2_client.models import Lab
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def _make_lab_context() -> tuple[Lab, MagicMock, MagicMock]:

--- a/tests/test_labs.py
+++ b/tests/test_labs.py
@@ -21,15 +21,18 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import pytest
-from respx import MockRouter
 
 from tests.helpers import RESOURCE_POOL_MANAGER, USER_MANAGEMENT, make_lab
 from virl2_client.exceptions import VirlException
 from virl2_client.models import Lab
 from virl2_client.models.authentication import make_session
+
+if TYPE_CHECKING:
+    from respx import MockRouter
 
 
 def test_topology_create_stats() -> None:

--- a/tests/test_link_runtime.py
+++ b/tests/test_link_runtime.py
@@ -21,12 +21,15 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
 
 from tests.helpers import make_lab_with_topology
-from virl2_client.models import Link
+
+if TYPE_CHECKING:
+    from virl2_client.models import Link
 
 
 def _new_link() -> Link:

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -21,14 +21,17 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
-from respx import MockRouter
 
 from tests.helpers import RESOURCE_POOL_MANAGER, USER_MANAGEMENT
 from virl2_client.models import Interface, Lab
 from virl2_client.models.authentication import make_session
+
+if TYPE_CHECKING:
+    from respx import MockRouter
 
 
 @pytest.mark.parametrize("connect_two_nodes", [True, False])

--- a/tests/test_node_image_definitions.py
+++ b/tests/test_node_image_definitions.py
@@ -24,10 +24,9 @@ from __future__ import annotations
 import contextlib
 import pathlib
 import sys
-from collections.abc import Iterator
 from io import BufferedReader
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import ANY, MagicMock, patch
 
 import pytest
@@ -38,7 +37,11 @@ from virl2_client.models.node_image_definition import (
     NodeImageDefinitions,
     print_progress_bar,
 )
-from virl2_client.virl2_client import ClientLibrary
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from virl2_client.virl2_client import ClientLibrary
 
 
 @pytest.mark.parametrize(

--- a/tests/test_system_lab_repositories.py
+++ b/tests/test_system_lab_repositories.py
@@ -54,8 +54,7 @@ def mock_lab_repository_management() -> LabRepositoryManagement:
     """
     session_mock = Mock()
     system_mock = Mock()
-    lab_repo_mgmt = LabRepositoryManagement(system_mock, session_mock, auto_sync=False)
-    return lab_repo_mgmt
+    return LabRepositoryManagement(system_mock, session_mock, auto_sync=False)
 
 
 @pytest.fixture
@@ -467,10 +466,9 @@ def test_lab_repository_end_to_end_workflow() -> None:
         _ = request
         if deleted[0]:
             return httpx.Response(200, json=[])
-        elif len(respx.calls) >= 4:
+        if len(respx.calls) >= 4:
             return httpx.Response(200, json=[MOCK_LAB_REPOSITORY_1])
-        else:
-            return httpx.Response(200, json=[])
+        return httpx.Response(200, json=[])
 
     def delete_lab_repo_response(request: httpx.Request) -> httpx.Response:
         """Mark repository as deleted in mocked backend state.

--- a/tests/test_utils_stale.py
+++ b/tests/test_utils_stale.py
@@ -149,7 +149,7 @@ def test_check_stale_decorator_raises_for_stale() -> None:
     @check_stale
     def f(_self: Lab) -> None:
         """No-op helper used only to trigger stale guard."""
-        return None
+        return
 
     with pytest.raises(LabNotFound):
         f(instance)
@@ -247,7 +247,7 @@ def test_deprecated_argument_warns_and_ignores_none() -> None:
     class Dummy:
         def method(self) -> None:
             """No-op method for deprecation warning origin."""
-            return None
+            return
 
     dummy = Dummy()
     with pytest.deprecated_call(match="The argument 'offline' is deprecated"):

--- a/virl2_client/event_handling.py
+++ b/virl2_client/event_handling.py
@@ -123,6 +123,7 @@ class EventHandlerBase(ABC):
 
         :param event: An Event object representing the lab created event.
         """
+        pass
 
     @abstractmethod
     def _handle_lab_modified(self, event: Event) -> None:
@@ -131,6 +132,7 @@ class EventHandlerBase(ABC):
 
         :param event: An Event object representing the lab modified event.
         """
+        pass
 
     @abstractmethod
     def _handle_lab_deleted(self, event: Event) -> None:
@@ -139,6 +141,7 @@ class EventHandlerBase(ABC):
 
         :param event: An Event object representing the lab deleted event.
         """
+        pass
 
     @abstractmethod
     def _handle_lab_state(self, event: Event) -> None:
@@ -147,6 +150,7 @@ class EventHandlerBase(ABC):
 
         :param event: An Event object representing the lab state event.
         """
+        pass
 
     def _handle_element(self, event: Event) -> None:
         """
@@ -175,6 +179,7 @@ class EventHandlerBase(ABC):
 
         :param event: An Event object representing the element created event.
         """
+        pass
 
     @abstractmethod
     def _handle_element_modified(self, event: Event) -> None:
@@ -183,6 +188,7 @@ class EventHandlerBase(ABC):
 
         :param event: An Event object representing the element modified event.
         """
+        pass
 
     @abstractmethod
     def _handle_element_deleted(self, event: Event) -> None:
@@ -191,6 +197,7 @@ class EventHandlerBase(ABC):
 
         :param event: An Event object representing the element deleted event.
         """
+        pass
 
     @abstractmethod
     def _handle_state_change(self, event: Event) -> None:
@@ -199,6 +206,7 @@ class EventHandlerBase(ABC):
 
         :param event: An Event object representing the state change event.
         """
+        pass
 
     def _handle_other(self, event: Event) -> None:  # noqa: ARG002 -- `event` is part of the documented subclass-override contract
         """
@@ -264,6 +272,7 @@ class EventHandler(EventHandlerBase):
         """
         # we don't care about labs the user hasn't joined,
         # so we don't need the lab creation event
+        pass
 
     def _handle_lab_modified(self, event: Event) -> None:
         """Apply lab property updates.

--- a/virl2_client/event_handling.py
+++ b/virl2_client/event_handling.py
@@ -123,7 +123,6 @@ class EventHandlerBase(ABC):
 
         :param event: An Event object representing the lab created event.
         """
-        pass
 
     @abstractmethod
     def _handle_lab_modified(self, event: Event) -> None:
@@ -132,7 +131,6 @@ class EventHandlerBase(ABC):
 
         :param event: An Event object representing the lab modified event.
         """
-        pass
 
     @abstractmethod
     def _handle_lab_deleted(self, event: Event) -> None:
@@ -141,7 +139,6 @@ class EventHandlerBase(ABC):
 
         :param event: An Event object representing the lab deleted event.
         """
-        pass
 
     @abstractmethod
     def _handle_lab_state(self, event: Event) -> None:
@@ -150,7 +147,6 @@ class EventHandlerBase(ABC):
 
         :param event: An Event object representing the lab state event.
         """
-        pass
 
     def _handle_element(self, event: Event) -> None:
         """
@@ -179,7 +175,6 @@ class EventHandlerBase(ABC):
 
         :param event: An Event object representing the element created event.
         """
-        pass
 
     @abstractmethod
     def _handle_element_modified(self, event: Event) -> None:
@@ -188,7 +183,6 @@ class EventHandlerBase(ABC):
 
         :param event: An Event object representing the element modified event.
         """
-        pass
 
     @abstractmethod
     def _handle_element_deleted(self, event: Event) -> None:
@@ -197,7 +191,6 @@ class EventHandlerBase(ABC):
 
         :param event: An Event object representing the element deleted event.
         """
-        pass
 
     @abstractmethod
     def _handle_state_change(self, event: Event) -> None:
@@ -206,7 +199,6 @@ class EventHandlerBase(ABC):
 
         :param event: An Event object representing the state change event.
         """
-        pass
 
     def _handle_other(self, event: Event) -> None:  # noqa: ARG002 -- `event` is part of the documented subclass-override contract
         """
@@ -260,9 +252,8 @@ class EventHandler(EventHandlerBase):
                     # (e.g. node being deleted and all its links and interfaces being
                     # deleted with it) so the event is useless
                     return
-                else:
-                    # A modify event arrived for a missing element - something is wrong
-                    raise
+                # A modify event arrived for a missing element - something is wrong
+                raise
 
         super().handle_event(event)
 
@@ -273,7 +264,6 @@ class EventHandler(EventHandlerBase):
         """
         # we don't care about labs the user hasn't joined,
         # so we don't need the lab creation event
-        pass
 
     def _handle_lab_modified(self, event: Event) -> None:
         """Apply lab property updates.

--- a/virl2_client/event_listening.py
+++ b/virl2_client/event_listening.py
@@ -26,7 +26,6 @@ import json
 import logging
 import ssl
 import threading
-from collections.abc import Coroutine
 from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
@@ -36,6 +35,8 @@ import aiohttp
 from .event_handling import Event, EventHandler
 
 if TYPE_CHECKING:
+    from collections.abc import Coroutine
+
     from .virl2_client import ClientLibrary
 
 _LOGGER = logging.getLogger(__name__)

--- a/virl2_client/exceptions.py
+++ b/virl2_client/exceptions.py
@@ -26,100 +26,80 @@ class VirlException(Exception):
     """Base exception for all virl2_client errors."""
 
 
-
 class InitializationError(VirlException):
     """Raised when the client library cannot be initialized."""
-
 
 
 class ElementAlreadyExists(VirlException, FileExistsError):
     """Raised when attempting to create an element that already exists."""
 
 
-
 class ElementNotFound(VirlException, KeyError):
     """Raised when a requested element does not exist."""
-
 
 
 class AnnotationNotFound(ElementNotFound):
     """Raised when a requested annotation does not exist."""
 
 
-
 class SmartAnnotationNotFound(ElementNotFound):
     """Raised when a requested smart annotation does not exist."""
-
 
 
 class NodeNotFound(ElementNotFound):
     """Raised when a requested node does not exist."""
 
 
-
 class LinkNotFound(ElementNotFound):
     """Raised when a requested link does not exist."""
-
 
 
 class InterfaceNotFound(ElementNotFound):
     """Raised when a requested interface does not exist."""
 
 
-
 class LabNotFound(ElementNotFound):
     """Raised when a requested lab does not exist."""
-
 
 
 class LabRepositoryNotFound(ElementNotFound):
     """Raised when a requested lab repository does not exist."""
 
 
-
 class InvalidContentType(VirlException):
     """Raised when an unsupported content type is encountered."""
-
 
 
 class InvalidImageFile(VirlException):
     """Raised when an image file is invalid or has an unsupported format."""
 
 
-
 class InvalidAnnotationType(VirlException):
     """Raised when an unsupported annotation type is used."""
-
 
 
 class InvalidProperty(VirlException):
     """Raised when an invalid property is set on a model object."""
 
 
-
 class InvalidTopologySchema(VirlException):
     """Raised when a topology definition does not match the expected schema."""
-
 
 
 class MethodNotActive(VirlException):
     """Raised when a method is called that is not currently active or enabled."""
 
 
-
 class PyatsException(VirlException):
     """Base exception for pyATS integration errors."""
-
 
 
 class PyatsNotInstalled(PyatsException):
     """Raised when pyATS is required but not installed."""
 
 
-
 class PyatsDeviceNotFound(PyatsException):
     """Raised when a requested pyATS device does not exist."""
-
 
 
 class ControllerNotFound(VirlException):
@@ -131,7 +111,6 @@ class ControllerNotFound(VirlException):
 
 class APIError(VirlException, httpx.HTTPStatusError):
     """Raised when the CML REST API returns an HTTP error response."""
-
 
 
 class FeatureNotSupported(VirlException):

--- a/virl2_client/exceptions.py
+++ b/virl2_client/exceptions.py
@@ -25,81 +25,121 @@ import httpx
 class VirlException(Exception):
     """Base exception for all virl2_client errors."""
 
+    pass
+
 
 class InitializationError(VirlException):
     """Raised when the client library cannot be initialized."""
+
+    pass
 
 
 class ElementAlreadyExists(VirlException, FileExistsError):
     """Raised when attempting to create an element that already exists."""
 
+    pass
+
 
 class ElementNotFound(VirlException, KeyError):
     """Raised when a requested element does not exist."""
+
+    pass
 
 
 class AnnotationNotFound(ElementNotFound):
     """Raised when a requested annotation does not exist."""
 
+    pass
+
 
 class SmartAnnotationNotFound(ElementNotFound):
     """Raised when a requested smart annotation does not exist."""
+
+    pass
 
 
 class NodeNotFound(ElementNotFound):
     """Raised when a requested node does not exist."""
 
+    pass
+
 
 class LinkNotFound(ElementNotFound):
     """Raised when a requested link does not exist."""
+
+    pass
 
 
 class InterfaceNotFound(ElementNotFound):
     """Raised when a requested interface does not exist."""
 
+    pass
+
 
 class LabNotFound(ElementNotFound):
     """Raised when a requested lab does not exist."""
+
+    pass
 
 
 class LabRepositoryNotFound(ElementNotFound):
     """Raised when a requested lab repository does not exist."""
 
+    pass
+
 
 class InvalidContentType(VirlException):
     """Raised when an unsupported content type is encountered."""
+
+    pass
 
 
 class InvalidImageFile(VirlException):
     """Raised when an image file is invalid or has an unsupported format."""
 
+    pass
+
 
 class InvalidAnnotationType(VirlException):
     """Raised when an unsupported annotation type is used."""
+
+    pass
 
 
 class InvalidProperty(VirlException):
     """Raised when an invalid property is set on a model object."""
 
+    pass
+
 
 class InvalidTopologySchema(VirlException):
     """Raised when a topology definition does not match the expected schema."""
+
+    pass
 
 
 class MethodNotActive(VirlException):
     """Raised when a method is called that is not currently active or enabled."""
 
+    pass
+
 
 class PyatsException(VirlException):
     """Base exception for pyATS integration errors."""
+
+    pass
 
 
 class PyatsNotInstalled(PyatsException):
     """Raised when pyATS is required but not installed."""
 
+    pass
+
 
 class PyatsDeviceNotFound(PyatsException):
     """Raised when a requested pyATS device does not exist."""
+
+    pass
 
 
 class ControllerNotFound(VirlException):
@@ -111,6 +151,8 @@ class ControllerNotFound(VirlException):
 
 class APIError(VirlException, httpx.HTTPStatusError):
     """Raised when the CML REST API returns an HTTP error response."""
+
+    pass
 
 
 class FeatureNotSupported(VirlException):

--- a/virl2_client/exceptions.py
+++ b/virl2_client/exceptions.py
@@ -25,121 +25,101 @@ import httpx
 class VirlException(Exception):
     """Base exception for all virl2_client errors."""
 
-    pass
 
 
 class InitializationError(VirlException):
     """Raised when the client library cannot be initialized."""
 
-    pass
 
 
 class ElementAlreadyExists(VirlException, FileExistsError):
     """Raised when attempting to create an element that already exists."""
 
-    pass
 
 
 class ElementNotFound(VirlException, KeyError):
     """Raised when a requested element does not exist."""
 
-    pass
 
 
 class AnnotationNotFound(ElementNotFound):
     """Raised when a requested annotation does not exist."""
 
-    pass
 
 
 class SmartAnnotationNotFound(ElementNotFound):
     """Raised when a requested smart annotation does not exist."""
 
-    pass
 
 
 class NodeNotFound(ElementNotFound):
     """Raised when a requested node does not exist."""
 
-    pass
 
 
 class LinkNotFound(ElementNotFound):
     """Raised when a requested link does not exist."""
 
-    pass
 
 
 class InterfaceNotFound(ElementNotFound):
     """Raised when a requested interface does not exist."""
 
-    pass
 
 
 class LabNotFound(ElementNotFound):
     """Raised when a requested lab does not exist."""
 
-    pass
 
 
 class LabRepositoryNotFound(ElementNotFound):
     """Raised when a requested lab repository does not exist."""
 
-    pass
 
 
 class InvalidContentType(VirlException):
     """Raised when an unsupported content type is encountered."""
 
-    pass
 
 
 class InvalidImageFile(VirlException):
     """Raised when an image file is invalid or has an unsupported format."""
 
-    pass
 
 
 class InvalidAnnotationType(VirlException):
     """Raised when an unsupported annotation type is used."""
 
-    pass
 
 
 class InvalidProperty(VirlException):
     """Raised when an invalid property is set on a model object."""
 
-    pass
 
 
 class InvalidTopologySchema(VirlException):
     """Raised when a topology definition does not match the expected schema."""
 
-    pass
 
 
 class MethodNotActive(VirlException):
     """Raised when a method is called that is not currently active or enabled."""
 
-    pass
 
 
 class PyatsException(VirlException):
     """Base exception for pyATS integration errors."""
 
-    pass
 
 
 class PyatsNotInstalled(PyatsException):
     """Raised when pyATS is required but not installed."""
 
-    pass
 
 
 class PyatsDeviceNotFound(PyatsException):
     """Raised when a requested pyATS device does not exist."""
 
-    pass
 
 
 class ControllerNotFound(VirlException):
@@ -152,7 +132,6 @@ class ControllerNotFound(VirlException):
 class APIError(VirlException, httpx.HTTPStatusError):
     """Raised when the CML REST API returns an HTTP error response."""
 
-    pass
 
 
 class FeatureNotSupported(VirlException):

--- a/virl2_client/models/authentication.py
+++ b/virl2_client/models/authentication.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import json
 import logging
-from collections.abc import Generator
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, ClassVar
 from uuid import uuid4
 
@@ -33,6 +33,8 @@ from ..exceptions import APIError
 _LOGGER = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
+
     from ..virl2_client import ClientLibrary
 
 
@@ -106,7 +108,7 @@ class TokenAuth(httpx.Auth):
         response = self.client_library._session.post(
             _AUTH_URL,
             json=data,
-            auth=None,  # type: ignore
+            auth=None,  # type: ignore[arg-type]
         )  # auth=None works but is missing from .post's type hint
         raise_for_status(response)
         self.client_library.jwtoken = response.json()
@@ -179,10 +181,12 @@ class BlankAuth(httpx.Auth):
 class CustomClient(httpx.Client):
     """httpx Client that raises APIError with server description on HTTP errors."""
 
-    _ERROR_PREFIX: ClassVar[dict[int, str]] = {
-        4: "Client error - ",
-        5: "Server error - ",
-    }
+    _ERROR_PREFIX: ClassVar[dict[int, str]] = MappingProxyType(
+        {
+            4: "Client error - ",
+            5: "Server error - ",
+        }
+    )
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """

--- a/virl2_client/models/cl_pyats.py
+++ b/virl2_client/models/cl_pyats.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import io
 import logging
 import os
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 try:
@@ -45,6 +44,8 @@ else:
 from ..exceptions import PyatsDeviceNotFound, PyatsNotInstalled
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from genie.libs.conf.device import Device
     from genie.libs.conf.testbed import Testbed
 
@@ -461,6 +462,7 @@ def _remove_unicon_loggers(pyats_device: Device) -> None:
     except (AttributeError, TypeError, KeyError):
         return
     for name in names:
-        while name.startswith("unicon."):
-            loggers.pop(name, None)
-            name = name.rsplit(".", 1)[0]
+        current_name = name
+        while current_name.startswith("unicon."):
+            loggers.pop(current_name, None)
+            current_name = current_name.rsplit(".", 1)[0]

--- a/virl2_client/models/lab.py
+++ b/virl2_client/models/lab.py
@@ -24,7 +24,6 @@ import contextlib
 import json
 import logging
 import time
-from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from httpx import HTTPStatusError
@@ -57,6 +56,8 @@ from .node import Node
 from .smart_annotation import SmartAnnotation
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     import httpx
 
     from .annotation import AnnotationType
@@ -799,8 +800,7 @@ class Lab:
                 kwargs[key] = None
         kwargs["resource_pool"] = None
         kwargs.pop("compute_id", None)
-        node = self._create_node_local(node_id, **kwargs)
-        return node
+        return self._create_node_local(node_id, **kwargs)
 
     @locked
     def _create_node_local(
@@ -1087,8 +1087,7 @@ class Lab:
         if self.need_to_wait(wait):
             self.wait_until_lab_converged()
 
-        link = self._create_link_local(i1, i2, link_id, label)
-        return link
+        return self._create_link_local(i1, i2, link_id, label)
 
     @check_stale
     @locked
@@ -1230,12 +1229,11 @@ class Lab:
         if not self._initialized:
             self._initialized = True
 
-        annotation = self._create_annotation_local(
+        return self._create_annotation_local(
             res_annotation["id"],
             annotation_type,
             **res_annotation,
         )
-        return annotation
 
     @check_stale
     @locked
@@ -1455,8 +1453,7 @@ class Lab:
         :returns: True if the lab has converged, False otherwise.
         """
         url = self._url_for("check_if_converged")
-        converged = self._session.get(url).json()
-        return converged
+        return self._session.get(url).json()
 
     @check_stale
     def start(self, wait: bool | None = None) -> None:
@@ -1898,10 +1895,9 @@ class Lab:
             if key not in ("id", "type")
         }
 
-        annotation = self._create_annotation_local(
+        return self._create_annotation_local(
             annotation_id, annotation_type, **annotation_data
         )
-        return annotation
 
     @locked
     def _import_smart_annotation(
@@ -1919,10 +1915,9 @@ class Lab:
         annotation_data = {
             key: annotation_data[key] for key in annotation_data if key != "id"
         }
-        annotation = self._create_smart_annotation_local(
+        return self._create_smart_annotation_local(
             annotation_id, **annotation_data
         )
-        return annotation
 
     @locked
     def update_lab(self, topology: dict, exclude_configurations: bool) -> None:
@@ -2099,8 +2094,8 @@ class Lab:
             for interface in interfaces:
                 interface_id = interface["id"]
                 if interface_id in new_interfaces:
-                    interface = self._import_interface(interface_id, node_id, interface)
-                    _LOGGER.info("Added interface %s", interface)
+                    imported_interface = self._import_interface(interface_id, node_id, interface)
+                    _LOGGER.info("Added interface %s", imported_interface)
 
     @locked
     def _add_interfaces(self, topology: dict, new_interfaces: Iterable[str]) -> None:

--- a/virl2_client/models/lab.py
+++ b/virl2_client/models/lab.py
@@ -1915,9 +1915,7 @@ class Lab:
         annotation_data = {
             key: annotation_data[key] for key in annotation_data if key != "id"
         }
-        return self._create_smart_annotation_local(
-            annotation_id, **annotation_data
-        )
+        return self._create_smart_annotation_local(annotation_id, **annotation_data)
 
     @locked
     def update_lab(self, topology: dict, exclude_configurations: bool) -> None:
@@ -2094,7 +2092,9 @@ class Lab:
             for interface in interfaces:
                 interface_id = interface["id"]
                 if interface_id in new_interfaces:
-                    imported_interface = self._import_interface(interface_id, node_id, interface)
+                    imported_interface = self._import_interface(
+                        interface_id, node_id, interface
+                    )
                     _LOGGER.info("Added interface %s", imported_interface)
 
     @locked

--- a/virl2_client/models/lab_repository.py
+++ b/virl2_client/models/lab_repository.py
@@ -24,12 +24,12 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any, ClassVar
 
-import httpx
-
 from ..exceptions import LabRepositoryNotFound
 from ..utils import _requires_version, get_url_from_template
 
 if TYPE_CHECKING:
+    import httpx
+
     from .system import SystemManagement
 
 _LOGGER = logging.getLogger(__name__)

--- a/virl2_client/models/node.py
+++ b/virl2_client/models/node.py
@@ -26,8 +26,6 @@ import time
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, ClassVar
 
-import httpx
-
 from ..exceptions import InterfaceNotFound, SmartAnnotationNotFound
 from ..utils import (
     UNCHANGED,
@@ -40,6 +38,8 @@ from ..utils import (
 from ..utils import property_s as property
 
 if TYPE_CHECKING:
+    import httpx
+
     from .interface import Interface
     from .lab import Lab
     from .link import Link

--- a/virl2_client/models/node_image_definition.py
+++ b/virl2_client/models/node_image_definition.py
@@ -24,13 +24,14 @@ import logging
 import os
 import pathlib
 import time
-from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, BinaryIO, ClassVar
 
 from ..exceptions import InvalidContentType, InvalidImageFile
 from ..utils import _requires_version, get_url_from_template
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     import httpx
 
 _LOGGER = logging.getLogger(__name__)
@@ -145,9 +146,8 @@ class NodeImageDefinitions:
         method = "PUT" if update else "POST"
         if is_json:
             return self._session.request(method, url, json=body).json()
-        else:
-            # YAML
-            return self._session.request(method, url, content=body).json()
+        # YAML
+        return self._session.request(method, url, content=body).json()
 
     def upload_image_definition(
         self, body: str | dict, update: bool = False
@@ -164,9 +164,8 @@ class NodeImageDefinitions:
         method = "PUT" if update else "POST"
         if is_json:
             return self._session.request(method, url, json=body).json()
-        else:
-            # YAML
-            return self._session.request(method, url, content=body).json()
+        # YAML
+        return self._session.request(method, url, content=body).json()
 
     def download_node_definition(self, definition_id: str) -> str:
         """
@@ -377,6 +376,6 @@ def _is_json_content(content: dict[str, Any] | str) -> bool:
     """
     if isinstance(content, dict):
         return True
-    elif isinstance(content, str):
+    if isinstance(content, str):
         return False
     raise InvalidContentType(type(content))

--- a/virl2_client/models/resource_pool.py
+++ b/virl2_client/models/resource_pool.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 import logging
 import time
-from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -30,6 +29,8 @@ from ..exceptions import InvalidProperty
 from ..utils import get_url_from_template
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     import httpx
 
 _LOGGER = logging.getLogger(__name__)

--- a/virl2_client/models/system.py
+++ b/virl2_client/models/system.py
@@ -279,9 +279,8 @@ class SystemManagement:
         url = self._url_for("external_connectors")
         if sync is None:
             return self._session.get(url).json()
-        else:
-            data = {"push_configured_state": sync}
-            return self._session.put(url, json=data).json()
+        data = {"push_configured_state": sync}
+        return self._session.put(url, json=data).json()
 
     def update_external_connector(
         self, connector_id: str, data: dict[str, Any]

--- a/virl2_client/utils.py
+++ b/virl2_client/utils.py
@@ -221,7 +221,7 @@ def check_stale(func: TCallable) -> TCallable:
         """
         return _check_and_mark_stale(func, args[0], *args, **kwargs)
 
-    return cast(TCallable, wrapper_stale)
+    return cast("TCallable", wrapper_stale)
 
 
 class property_s(property):
@@ -286,7 +286,7 @@ def locked(func: TCallable) -> TCallable:
         with ctx:
             return func(*args, **kwargs)
 
-    return cast(TCallable, wrapper_locked)
+    return cast("TCallable", wrapper_locked)
 
 
 def get_url_from_template(
@@ -356,6 +356,6 @@ def _requires_version(min_version: str) -> Callable:
                 )
             return func(self, *args, **kwargs)
 
-        return cast(TCallable, wrapper)
+        return cast("TCallable", wrapper)
 
     return decorator

--- a/virl2_client/virl2_client.py
+++ b/virl2_client/virl2_client.py
@@ -207,6 +207,7 @@ class ClientConfig(NamedTuple):
             cls._populate_from_inputs(config)
         if cls._validate(config, final=True):
             return cls(**config)
+        return None
 
 
 class DiagnosticsCategory(Enum):
@@ -331,9 +332,8 @@ class ClientLibrary:
         except InitializationError as exc:
             if raise_for_auth_failure:
                 raise
-            else:
-                _LOGGER.warning(exc)
-                return
+            _LOGGER.warning(exc)
+            return
 
         self.event_listener = None
         self._session.lock = None


### PR DESCRIPTION
- enable BLE,FURB,ISC,Q,FA,T10,TD,FIX,PGH,TCH,PIE,RET in ruff select
- remove PLW2901 from ignore list
- apply mechanical TCH/RET/PIE cleanups across library and tests
- fix remaining manual lint items:
  - PGH003 in authentication type-ignore
  - PLW2901 loop-var reassignment in cl_pyats and lab
- keep behavior unchanged; lint clean and full test suite passing