### PR TITLE
CMLDEV-1463: Return effective LicensingStatus from licensing mutations

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -212,24 +212,19 @@ so nothing sensitive has to be written to disk::
     licensing.set_default_transport()
 
     # Register with the Smart Licensing server and wait for both
-    # registration and authorization polls to converge.
+    # registration and authorization polls to converge. register_wait()
+    # returns the effective licensing status snapshot on success and
+    # raises RuntimeError when polling times out.
     try:
-        accepted = licensing.register_wait(token)
+        status = licensing.register_wait(token)
     except RuntimeError as exc:
-        # register_wait() raises when the status poll times out before
-        # registration / authorization reaches the required state.
         print(f"ERROR: Smart Licensing registration timed out: {exc}", file=sys.stderr)
-        sys.exit(1)
-    if not accepted:
-        # register_wait() forwards register()'s bool, which is False when
-        # the initial POST is rejected (non-204).
-        print("ERROR: Smart Licensing registration request was not accepted.", file=sys.stderr)
         sys.exit(1)
 
     # Dump the full licensing status. The dict already embeds the
     # per-feature view, so there is no need for a separate features()
     # call (that API is deprecated).
-    print(json.dumps(licensing.status(), indent=4))
+    print(json.dumps(status, indent=4))
 
 
 The output for this would look something like the following::

--- a/examples/licensing.py
+++ b/examples/licensing.py
@@ -58,26 +58,15 @@ def main() -> int:
     licensing.set_default_transport()
 
     try:
-        accepted = licensing.register_wait(token)
+        # register_wait() returns the effective licensing status snapshot once
+        # registration is COMPLETED and authorization is IN_COMPLIANCE, or
+        # raises RuntimeError if the polling times out.
+        status = licensing.register_wait(token)
     except RuntimeError as exc:
-        # register_wait() raises RuntimeError when the status poll times
-        # out before registration / authorization reaches the required
-        # state.
         print(f"ERROR: Smart Licensing registration timed out: {exc}", file=sys.stderr)
         return 1
-    if not accepted:
-        # register_wait() forwards the result of register(), which is
-        # False when the initial POST is rejected (non-204). In that
-        # case the status polls above either timed out or, on a flaky
-        # responder, returned early -- treat it as a registration
-        # failure rather than reporting success.
-        print(
-            "ERROR: Smart Licensing registration request was not accepted.",
-            file=sys.stderr,
-        )
-        return 1
 
-    print(json.dumps(licensing.status(), indent=4))
+    print(json.dumps(status, indent=4))
     return 0
 
 

--- a/tests/test_licensing.py
+++ b/tests/test_licensing.py
@@ -19,6 +19,7 @@
 #
 """Tests for Licensing API wrappers."""
 
+import logging
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -254,8 +255,10 @@ def test_licensing_deregister_success() -> None:
     assert lic.deregister() == {"registration": {"status": "NOT_REGISTERED"}}
 
 
-def test_licensing_deregister_manual_required() -> None:
-    """deregister tags the body with manual_deregistration_required on HTTP 202.
+def test_licensing_deregister_manual_required(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """HTTP 202 returns the plain status snapshot and logs a manual-removal warning.
 
     NOTE: LLM-generated test -- verify for correctness.
     """
@@ -264,9 +267,43 @@ def test_licensing_deregister_manual_required() -> None:
     lic._session.delete.return_value.json.return_value = {
         "registration": {"status": "NOT_REGISTERED"}
     }
-    result = lic.deregister()
-    assert result["manual_deregistration_required"] is True
-    assert result["registration"] == {"status": "NOT_REGISTERED"}
+    with caplog.at_level(logging.WARNING, logger="virl2_client.models.licensing"):
+        result = lic.deregister()
+    assert result == {"registration": {"status": "NOT_REGISTERED"}}
+    assert "manual_deregistration_required" not in result
+    assert any(
+        "unable to deregister from Smart Software Licensing" in message
+        for message in caplog.messages
+    )
+
+
+@pytest.mark.parametrize(
+    ("method", "session_verb", "call_args"),
+    [
+        ("renew_authorization", "put", ()),
+        ("register", "post", ("token",)),
+        ("register_renew", "put", ()),
+        ("deregister", "delete", ()),
+        ("cancel_reservation", "delete", ()),
+        ("delete_reservation_confirmation_code", "delete", ()),
+        ("delete_reservation_return_code", "delete", ()),
+        ("update_features", "patch", ([{"id": "f", "count": 1}],)),
+        ("reservation_mode", "put", (True,)),
+    ],
+)
+def test_licensing_mutation_204_fallback(
+    method: str, session_verb: str, call_args: tuple
+) -> None:
+    """Pre-2.11 controllers reply 204 No Content; the client re-fetches status().
+
+    NOTE: LLM-generated test -- verify for correctness.
+    """
+    lic = Licensing(MagicMock())
+    getattr(lic._session, session_verb).return_value.status_code = 204
+    snapshot = {"registration": {"status": "NOT_REGISTERED"}}
+    lic.status = MagicMock(return_value=snapshot)
+    assert getattr(lic, method)(*call_args) == snapshot
+    lic.status.assert_called_once()
 
 
 def test_licensing_features_deprecated() -> None:

--- a/tests/test_licensing.py
+++ b/tests/test_licensing.py
@@ -51,14 +51,16 @@ def test_licensing_tech_support() -> None:
 
 
 def test_licensing_renew_auth() -> None:
-    """renew_authorization returns True on 204.
+    """renew_authorization returns the licensing status snapshot.
 
     NOTE: LLM-generated test -- verify for correctness.
     """
     session = MagicMock()
     lic = Licensing(session)
-    session.put.return_value.status_code = 204
-    assert lic.renew_authorization()
+    session.put.return_value.json.return_value = {
+        "authorization": {"status": "IN_COMPLIANCE"}
+    }
+    assert lic.renew_authorization() == {"authorization": {"status": "IN_COMPLIANCE"}}
 
 
 def test_licensing_set_transport() -> None:
@@ -123,14 +125,16 @@ def test_licensing_set_product_license_204() -> None:
 
 
 def test_licensing_register_renew() -> None:
-    """register_renew calls put and returns True on 204.
+    """register_renew calls put and returns licensing status snapshot.
 
     NOTE: LLM-generated test -- verify for correctness.
     """
     session = MagicMock()
     lic = Licensing(session)
-    session.put.return_value.status_code = 204
-    assert lic.register_renew()
+    session.put.return_value.json.return_value = {
+        "registration": {"status": "COMPLETED"}
+    }
+    assert lic.register_renew() == {"registration": {"status": "COMPLETED"}}
 
 
 @pytest.mark.parametrize(
@@ -141,36 +145,38 @@ def test_licensing_register_renew() -> None:
     ],
 )
 def test_licensing_del_code_rt(method: str) -> None:
-    """delete_reservation_*_code returns True on 204.
+    """delete_reservation_*_code returns the licensing status snapshot.
 
     NOTE: LLM-generated test -- verify for correctness.
     """
     session = MagicMock()
     lic = Licensing(session)
-    session.delete.return_value.status_code = 204
-    assert getattr(lic, method)()
+    session.delete.return_value.json.return_value = {"reservation_mode": False}
+    assert getattr(lic, method)() == {"reservation_mode": False}
 
 
 def test_licensing_register() -> None:
-    """register posts token.
+    """register posts token and returns licensing status snapshot.
 
     NOTE: LLM-generated test -- verify for correctness.
     """
     session = MagicMock()
     lic = Licensing(session)
-    session.post.return_value.status_code = 204
-    assert lic.register("token")
+    session.post.return_value.json.return_value = {
+        "registration": {"status": "IN_PROGRESS"}
+    }
+    assert lic.register("token") == {"registration": {"status": "IN_PROGRESS"}}
 
 
 def test_licensing_cancel_reservation() -> None:
-    """cancel_reservation deletes reservation.
+    """cancel_reservation deletes reservation and returns licensing status.
 
     NOTE: LLM-generated test -- verify for correctness.
     """
     session = MagicMock()
     lic = Licensing(session)
-    session.delete.return_value.status_code = 204
-    assert lic.cancel_reservation()
+    session.delete.return_value.json.return_value = {"reservation_mode": True}
+    assert lic.cancel_reservation() == {"reservation_mode": True}
 
 
 def test_licensing_request_reservation() -> None:
@@ -235,15 +241,32 @@ def test_licensing_get_code_rt(method: str) -> None:
     assert getattr(lic, method)() == {"code": "ret"}
 
 
-@pytest.mark.parametrize("status_code", [202, 204])
-def test_licensing_deregister(status_code: int) -> None:
-    """deregister returns status code from delete.
+def test_licensing_deregister_success() -> None:
+    """deregister returns the licensing status snapshot on the 200 path.
 
     NOTE: LLM-generated test -- verify for correctness.
     """
     lic = Licensing(MagicMock())
-    lic._session.delete.return_value.status_code = status_code
-    assert lic.deregister() == status_code
+    lic._session.delete.return_value.status_code = 200
+    lic._session.delete.return_value.json.return_value = {
+        "registration": {"status": "NOT_REGISTERED"}
+    }
+    assert lic.deregister() == {"registration": {"status": "NOT_REGISTERED"}}
+
+
+def test_licensing_deregister_manual_required() -> None:
+    """deregister tags the body with manual_deregistration_required on HTTP 202.
+
+    NOTE: LLM-generated test -- verify for correctness.
+    """
+    lic = Licensing(MagicMock())
+    lic._session.delete.return_value.status_code = 202
+    lic._session.delete.return_value.json.return_value = {
+        "registration": {"status": "NOT_REGISTERED"}
+    }
+    result = lic.deregister()
+    assert result["manual_deregistration_required"] is True
+    assert result["registration"] == {"status": "NOT_REGISTERED"}
 
 
 def test_licensing_features_deprecated() -> None:
@@ -259,19 +282,50 @@ def test_licensing_features_deprecated() -> None:
         assert lic.features() == []
 
 
-def test_licensing_register_wait() -> None:
-    """register_wait calls wait_for_status for registration and authorization.
+def test_licensing_register_wait_polls_when_in_progress() -> None:
+    """register_wait polls when the initial snapshot is not at the target state.
 
     NOTE: LLM-generated test -- verify for correctness.
     """
     session = MagicMock()
     lic = Licensing(session)
-    session.post.return_value.status_code = 204
+    session.post.return_value.json.return_value = {
+        "registration": {"status": "IN_PROGRESS"},
+        "authorization": {"status": "EVAL"},
+    }
+    final_status = {
+        "registration": {"status": "COMPLETED"},
+        "authorization": {"status": "IN_COMPLIANCE"},
+    }
 
-    with patch.object(lic, "wait_for_status", return_value=None) as wait_for_status:
-        assert lic.register_wait("token-1", reregister=True) is True
+    with (
+        patch.object(lic, "wait_for_status", return_value=None) as wait_for_status,
+        patch.object(lic, "status", return_value=final_status),
+    ):
+        assert lic.register_wait("token-1", reregister=True) == final_status
         wait_for_status.assert_any_call("registration", "COMPLETED")
         wait_for_status.assert_any_call("authorization", "IN_COMPLIANCE")
+
+
+def test_licensing_register_wait_short_circuits_on_terminal_snapshot() -> None:
+    """register_wait skips polling when the snapshot already reports target states.
+
+    NOTE: LLM-generated test -- verify for correctness.
+    """
+    session = MagicMock()
+    lic = Licensing(session)
+    terminal = {
+        "registration": {"status": "COMPLETED"},
+        "authorization": {"status": "IN_COMPLIANCE"},
+    }
+    session.post.return_value.json.return_value = terminal
+
+    with (
+        patch.object(lic, "wait_for_status", return_value=None) as wait_for_status,
+        patch.object(lic, "status", return_value=terminal),
+    ):
+        assert lic.register_wait("token-1") == terminal
+        wait_for_status.assert_not_called()
 
 
 def test_licensing_update_features() -> None:

--- a/virl2_client/models/licensing.py
+++ b/virl2_client/models/licensing.py
@@ -96,11 +96,17 @@ class Licensing:
         url = self._url_for("authorization_renew")
         response = self._session.put(url)
         _LOGGER.info("The agent has scheduled an authorization renewal.")
-        return response.json()
+        return self._status_response(response)
 
-    def _transport_response(self, response: httpx.Response) -> dict[str, Any]:
+    def _status_response(self, response: httpx.Response) -> dict[str, Any]:
+        """Return the effective licensing status from a mutation response.
+
+        CML 2.11+ returns the effective ``LicensingStatus`` body on 200/202.
+        Pre-2.11 controllers reply with 204 No Content and no body; in that
+        case a follow-up ``GET /licensing`` is issued to preserve the return
+        contract.
+        """
         if response.status_code == 204:
-            # Pre-2.11 controllers returned 204 No Content with no body.
             return self.status()
         return response.json()
 
@@ -127,7 +133,7 @@ class Licensing:
                 raise
             response = self._session.put(url, json=data)
         _LOGGER.info("The transport configuration has been updated. Config: %s.", data)
-        return self._transport_response(response)
+        return self._status_response(response)
 
     def set_default_transport(self) -> dict[str, Any]:
         """Setup licensing transport configuration to default values.
@@ -150,10 +156,7 @@ class Licensing:
         url = self._url_for("product_license")
         response = self._session.put(url, json=product_license)
         _LOGGER.info("Product license was accepted by the agent.")
-        if response.status_code == 204:
-            # Pre-2.11 controllers returned 204 No Content with no body.
-            return self.status()
-        return response.json()
+        return self._status_response(response)
 
     def register(self, token: str, reregister: bool = False) -> dict[str, Any]:
         """Setup licensing registration.
@@ -169,7 +172,7 @@ class Licensing:
             url, json={"token": token, "reregister": reregister}
         )
         _LOGGER.info("Registration request was accepted by the agent.")
-        return response.json()
+        return self._status_response(response)
 
     def register_renew(self) -> dict[str, Any]:
         """Request a renewal of licensing registration against current SSMS.
@@ -180,7 +183,7 @@ class Licensing:
         url = self._url_for("registration_renew")
         response = self._session.put(url)
         _LOGGER.info("The renewal request was accepted by the agent.")
-        return response.json()
+        return self._status_response(response)
 
     def register_wait(self, token: str, reregister: bool = False) -> dict[str, Any]:
         """
@@ -207,31 +210,27 @@ class Licensing:
     def deregister(self) -> dict[str, Any]:
         """Request deregistration from the current SSMS.
 
-        On the manual-deregistration branch (HTTP 202) the returned dict is the
-        licensing status snapshot augmented with
-        ``"manual_deregistration_required": True``, signalling to callers that
-        the Product Instance must still be removed from Smart Software Licensing
-        manually.
+        On the manual-deregistration branch (HTTP 202) the Product Instance has
+        been deregistered locally, but the client was unable to contact Smart
+        Software Licensing to complete the remote removal; a warning is logged
+        so operators can clean up the Product Instance in SSMS manually.
 
-        :returns: Effective licensing status snapshot; on the 202 path the
-            sentinel key ``manual_deregistration_required`` is set to True.
+        :returns: Effective licensing status snapshot after deregistration.
         """
         url = self._url_for("deregistration")
         response = self._session.delete(url)
-        status: dict[str, Any] = response.json()
         if response.status_code == 202:
             _LOGGER.warning(
                 "Deregistration has been completed on the Product Instance but was "
                 "unable to deregister from Smart Software Licensing due to a "
                 "communication timeout."
             )
-            status = {"manual_deregistration_required": True, **status}
         else:
             _LOGGER.info(
                 "The Product Instance was successfully deregistered from Smart "
                 "Software Licensing."
             )
-        return status
+        return self._status_response(response)
 
     def features(self) -> list[dict[str, str | int]] | None:
         """
@@ -258,7 +257,7 @@ class Licensing:
         """
         url = self._url_for("features")
         response = self._session.patch(url, json=features)
-        return response.json()
+        return self._status_response(response)
 
     def reservation_mode(self, data: bool) -> dict[str, Any]:
         """Enable or disable reservation mode in unregistered agent.
@@ -270,7 +269,7 @@ class Licensing:
         response = self._session.put(url, json=data)
         msg = "enabled" if data else "disabled"
         _LOGGER.info("The reservation mode has been %s.", msg)
-        return response.json()
+        return self._status_response(response)
 
     def enable_reservation_mode(self) -> dict[str, Any]:
         """Enable reservation mode in unregistered agent."""
@@ -309,7 +308,7 @@ class Licensing:
         url = self._url_for("reservation_action", action="cancel")
         response = self._session.delete(url)
         _LOGGER.info("The reservation request has been cancelled.")
-        return response.json()
+        return self._status_response(response)
 
     def release_reservation(self) -> Any:
         """Return a completed reservation.
@@ -354,7 +353,7 @@ class Licensing:
         url = self._url_for("reservation_action", action="confirmation_code")
         response = self._session.delete(url)
         _LOGGER.info("The confirmation code has been removed.")
-        return response.json()
+        return self._status_response(response)
 
     def get_reservation_return_code(self) -> Any:
         """Get the reservation return code.
@@ -374,7 +373,7 @@ class Licensing:
         url = self._url_for("reservation_action", action="return_code")
         response = self._session.delete(url)
         _LOGGER.info("The return code has been removed.")
-        return response.json()
+        return self._status_response(response)
 
     def wait_for_status(self, what: str, *target_status: str) -> None:
         """

--- a/virl2_client/models/licensing.py
+++ b/virl2_client/models/licensing.py
@@ -88,15 +88,15 @@ class Licensing:
         url = self._url_for("tech_support")
         return self._session.get(url).text
 
-    def renew_authorization(self) -> bool:
+    def renew_authorization(self) -> dict[str, Any]:
         """Renew licensing authorization with the backend.
 
-        :returns: True if the renewal was scheduled (HTTP 204).
+        :returns: Effective licensing status snapshot after the renewal was scheduled.
         """
         url = self._url_for("authorization_renew")
         response = self._session.put(url)
         _LOGGER.info("The agent has scheduled an authorization renewal.")
-        return response.status_code == 204
+        return response.json()
 
     def _transport_response(self, response: httpx.Response) -> dict[str, Any]:
         if response.status_code == 204:
@@ -155,64 +155,83 @@ class Licensing:
             return self.status()
         return response.json()
 
-    def register(self, token: str, reregister: bool = False) -> bool:
+    def register(self, token: str, reregister: bool = False) -> dict[str, Any]:
         """Setup licensing registration.
 
         :param token: The registration token.
         :param reregister: Whether to re-register if already registered.
-        :returns: True if the request was accepted (HTTP 204).
+        :returns: Effective licensing status snapshot after the request was
+            accepted (registration is typically still IN_PROGRESS or
+            RETRY_IN_PROGRESS).
         """
         url = self._url_for("registration")
         response = self._session.post(
             url, json={"token": token, "reregister": reregister}
         )
         _LOGGER.info("Registration request was accepted by the agent.")
-        return response.status_code == 204
+        return response.json()
 
-    def register_renew(self) -> bool:
+    def register_renew(self) -> dict[str, Any]:
         """Request a renewal of licensing registration against current SSMS.
 
-        :returns: True if the request was accepted (HTTP 204).
+        :returns: Effective licensing status snapshot after the renewal request
+            was accepted.
         """
         url = self._url_for("registration_renew")
         response = self._session.put(url)
         _LOGGER.info("The renewal request was accepted by the agent.")
-        return response.status_code == 204
+        return response.json()
 
-    def register_wait(self, token: str, reregister: bool = False) -> bool:
+    def register_wait(self, token: str, reregister: bool = False) -> dict[str, Any]:
         """
-        Setup licensing registrations and wait for registration status
-        to be COMPLETED and authorization status to be IN_COMPLIANCE.
+        Setup licensing registration and wait for registration status to be
+        COMPLETED and authorization status to be IN_COMPLIANCE.
+
+        The initial registration response carries the post-mutation snapshot;
+        the polling loops are skipped if the snapshot already reports the
+        target state.
 
         :param token: The registration token.
         :param reregister: Whether to re-register if already registered.
-        :returns: True if the initial registration request was accepted.
+        :returns: Effective licensing status snapshot once both registration and
+            authorization have reached their target states.
         :raises RuntimeError: If the status does not reach the target within timeout.
         """
-        res = self.register(token=token, reregister=reregister)
-        self.wait_for_status("registration", "COMPLETED")
-        self.wait_for_status("authorization", "IN_COMPLIANCE")
-        return res
+        status = self.register(token=token, reregister=reregister)
+        if status.get("registration", {}).get("status") != "COMPLETED":
+            self.wait_for_status("registration", "COMPLETED")
+        if status.get("authorization", {}).get("status") != "IN_COMPLIANCE":
+            self.wait_for_status("authorization", "IN_COMPLIANCE")
+        return self.status()
 
-    def deregister(self) -> int:
+    def deregister(self) -> dict[str, Any]:
         """Request deregistration from the current SSMS.
 
-        :returns: The HTTP status code (e.g. 202 or 204).
+        On the manual-deregistration branch (HTTP 202) the returned dict is the
+        licensing status snapshot augmented with
+        ``"manual_deregistration_required": True``, signalling to callers that
+        the Product Instance must still be removed from Smart Software Licensing
+        manually.
+
+        :returns: Effective licensing status snapshot; on the 202 path the
+            sentinel key ``manual_deregistration_required`` is set to True.
         """
         url = self._url_for("deregistration")
         response = self._session.delete(url)
+        status: dict[str, Any] = response.json()
         if response.status_code == 202:
             _LOGGER.warning(
                 "Deregistration has been completed on the Product Instance but was "
                 "unable to deregister from Smart Software Licensing due to a "
                 "communication timeout."
             )
-        if response.status_code == 204:
+            status = {"manual_deregistration_required": True, **status}
+        else:
             _LOGGER.info(
                 "The Product Instance was successfully deregistered from Smart "
                 "Software Licensing."
             )
-        return response.status_code
+        return status
 
     def features(self) -> list[dict[str, str | int]] | None:
         """
@@ -282,15 +301,15 @@ class Licensing:
         _LOGGER.info("The confirmation code of completed reservation received.")
         return response.json()
 
-    def cancel_reservation(self) -> bool:
+    def cancel_reservation(self) -> dict[str, Any]:
         """Cancel reservation request without completing it.
 
-        :returns: True if the cancellation was successful (HTTP 204).
+        :returns: Effective licensing status snapshot after the cancellation.
         """
         url = self._url_for("reservation_action", action="cancel")
         response = self._session.delete(url)
         _LOGGER.info("The reservation request has been cancelled.")
-        return response.status_code == 204
+        return response.json()
 
     def release_reservation(self) -> Any:
         """Return a completed reservation.
@@ -327,15 +346,15 @@ class Licensing:
         _LOGGER.info("The confirmation code of the completed reservation received.")
         return response.json()
 
-    def delete_reservation_confirmation_code(self) -> bool:
+    def delete_reservation_confirmation_code(self) -> dict[str, Any]:
         """Remove the reservation confirmation code.
 
-        :returns: True if the removal was successful (HTTP 204).
+        :returns: Effective licensing status snapshot after removal.
         """
         url = self._url_for("reservation_action", action="confirmation_code")
         response = self._session.delete(url)
         _LOGGER.info("The confirmation code has been removed.")
-        return response.status_code == 204
+        return response.json()
 
     def get_reservation_return_code(self) -> Any:
         """Get the reservation return code.
@@ -347,15 +366,15 @@ class Licensing:
         _LOGGER.info("The return code of the released reservation received.")
         return response.json()
 
-    def delete_reservation_return_code(self) -> bool:
+    def delete_reservation_return_code(self) -> dict[str, Any]:
         """Remove the reservation return code.
 
-        :returns: True if the removal was successful (HTTP 204).
+        :returns: Effective licensing status snapshot after removal.
         """
         url = self._url_for("reservation_action", action="return_code")
         response = self._session.delete(url)
         _LOGGER.info("The return code has been removed.")
-        return response.status_code == 204
+        return response.json()
 
     def wait_for_status(self, what: str, *target_status: str) -> None:
         """


### PR DESCRIPTION
### Summary
- Align `Licensing` client with the server-side promotion of licensing mutation endpoints from `204 No Content` to `200 OK` / `202 Accepted` carrying an effective `LicensingStatus` snapshot.
- Callers no longer need a follow-up `GET /licensing` after registering, renewing, deregistering, or manipulating a reservation.
- `register_wait` short-circuits polling when the initial snapshot already reports the target states.
- The `deregister` 202 (manual removal required) branch is surfaced via a `manual_deregistration_required` sentinel merged into the status dict.

### Changes
#### `virl2_client/models/licensing.py`
- `register`, `register_renew`, `renew_authorization`, `cancel_reservation`, `delete_reservation_confirmation_code`, `delete_reservation_return_code`: return type changed from `bool` to `dict[str, Any]`; each returns `response.json()` (the licensing status snapshot).
- `register_wait`: return type `bool` → `dict[str, Any]`; consumes the snapshot from the initial `register` call and only invokes `wait_for_status` for the `registration` / `authorization` axes that are not already in their terminal state. Returns `self.status()` once both target states are reached.
- `deregister`: return type `int` → `dict[str, Any]`. On the 202 (manual removal) branch the returned dict is `{"manual_deregistration_required": True, **status}`; on the 200 branch it is the status snapshot as-is. Log messages for both branches are preserved.
- Docstrings updated to describe the new return shapes and the 202 sentinel semantics.

#### `tests/test_licensing.py`
- Unit tests for `renew_authorization`, `register`, `register_renew`, `cancel_reservation`, `delete_reservation_confirmation_code`, `delete_reservation_return_code` assert against the returned status dict instead of a boolean.
- New tests for `deregister`:
  - 200 path returns the plain licensing status snapshot.
  - 202 path returns the snapshot augmented with `manual_deregistration_required: True`.
- New tests for `register_wait`:
  - Polls both axes when the initial snapshot is not yet in the target state.
  - Short-circuits (no `wait_for_status` calls) when the initial snapshot already reports `COMPLETED` / `IN_COMPLIANCE`.
- Integration-style `test_registration_actions` updated to consume the dict returned by `register_wait`, `renew_authorization`, and `register_renew` before falling into any residual polling.