### PR TITLE
CMLDEV-1638 replace annotation border style wire values

### DIFF
--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -33,6 +33,7 @@ from virl2_client.models.annotation import (
     AnnotationRectangle,
     AnnotationText,
 )
+from virl2_client.utils import Version
 
 
 @pytest.mark.parametrize(
@@ -74,10 +75,11 @@ def test_annotation_subclass_setters(
     :param extra_updates: Subclass-specific properties to set and assert.
     """
     lab = make_lab()
+    lab._session.controller_version = Version("2.11.0")
     annotation = cls(lab, "a1")
     base_updates = {
         "border_color": "#11111111",
-        "border_style": "2,2",
+        "border_style": "dotted",
         "color": "#22222222",
         "thickness": 2,
         "x1": 3,
@@ -85,15 +87,31 @@ def test_annotation_subclass_setters(
         "z_index": 7,
     }
 
+    dotted_updates = {**base_updates, "border_style": "dotted"}
+
     with patch.object(annotation, "_set_annotation_property", return_value=None):
-        for key, value in base_updates.items():
+        for key, value in dotted_updates.items():
             setattr(annotation, key, value)
         for key, value in extra_updates.items():
             setattr(annotation, key, value)
             assert getattr(annotation, key) == value
 
-    for key, value in base_updates.items():
+    for key, value in dotted_updates.items():
         assert getattr(annotation, key) == value
+
+    with patch.object(
+        annotation, "_set_annotation_property", return_value=None
+    ) as setter:
+        lab._session.controller_version = Version("2.10.0")
+        annotation.border_style = "dotted"
+        setter.assert_called_with("border_style", "2,2")
+
+    with patch.object(
+        annotation, "_set_annotation_property", return_value=None
+    ) as setter:
+        lab._session.controller_version = Version("2.11.0")
+        annotation.border_style = "dotted"
+        setter.assert_called_with("border_style", "dotted")
 
 
 def test_annotation_set_props_patches() -> None:

--- a/tests/test_border_style.py
+++ b/tests/test_border_style.py
@@ -1,0 +1,65 @@
+#
+# This file is part of VIRL 2
+# Copyright (c) 2019-2026, Cisco Systems, Inc.
+# All rights reserved.
+#
+import pytest
+
+from virl2_client.models.border_style import (
+    border_style_for_api,
+    border_style_from_api,
+)
+from virl2_client.utils import Version
+
+
+@pytest.mark.parametrize(
+    ("wire", "expected"),
+    [
+        ("", "solid"),
+        ("2,2", "dotted"),
+        ("4,2", "dashed"),
+    ],
+)
+def test_border_style_from_api_legacy_controller(wire, expected):
+    assert border_style_from_api(wire, Version("2.10.0")) == expected
+
+
+@pytest.mark.parametrize(
+    ("wire", "expected"),
+    [
+        ("solid", "solid"),
+        ("dotted", "dotted"),
+        ("dashed", "dashed"),
+    ],
+)
+def test_border_style_from_api_modern_controller(wire, expected):
+    assert border_style_from_api(wire, Version("2.11.0")) == expected
+
+
+def test_border_style_from_api_modern_controller_rejects_legacy():
+    with pytest.raises(ValueError, match=r"'' is not a valid BorderStyle"):
+        border_style_from_api("", Version("2.11.0"))
+
+
+def test_border_style_from_api_legacy_controller_rejects_canonical():
+    with pytest.raises(KeyError):
+        border_style_from_api("solid", Version("2.10.0"))
+
+
+@pytest.mark.parametrize(
+    ("canonical", "controller", "expected"),
+    [
+        ("solid", "2.10.0", ""),
+        ("dotted", "2.10.0", "2,2"),
+        ("dashed", "2.10.0", "4,2"),
+        ("solid", "2.11.0", "solid"),
+        ("dotted", "2.11.0", "dotted"),
+    ],
+)
+def test_border_style_for_api(canonical, controller, expected):
+    assert border_style_for_api(canonical, Version(controller)) == expected
+
+
+def test_border_style_for_api_rejects_legacy_user_input():
+    with pytest.raises(ValueError, match=r"'2,2' is not a valid BorderStyle"):
+        border_style_for_api("2,2", Version("2.11.0"))

--- a/tests/test_smart_annotations.py
+++ b/tests/test_smart_annotations.py
@@ -45,7 +45,7 @@ def test_smart_annotation_prop_setters() -> None:
         "tag_size": 20,
         "group_distance": 500,
         "thickness": 3,
-        "border_style": "2,2",
+        "border_style": "dotted",
         "fill_color": "#33333333",
         "border_color": "#44444444",
         "z_index": 9,

--- a/virl2_client/models/annotation.py
+++ b/virl2_client/models/annotation.py
@@ -26,6 +26,11 @@ from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeAlias
 from ..exceptions import InvalidProperty
 from ..utils import check_stale, get_url_from_template, locked
 from ..utils import property_s as property
+from .border_style import (
+    BorderStyle,
+    border_style_for_api,
+    border_style_from_api,
+)
 
 if TYPE_CHECKING:
     import httpx
@@ -90,7 +95,7 @@ ANNOTATION_PROPERTIES_DEFAULTS = {
         "text": TRANSPARENT,
     },
     "border_radius": 0,
-    "border_style": "",
+    "border_style": "solid",
     "color": {
         "rectangle": WHITE,
         "ellipse": WHITE,
@@ -232,7 +237,7 @@ class Annotation:
         # set properties required by all annotations
         # values set to 'None' have type-specific default values
         self._border_color = None
-        self._border_style = ""
+        self._border_style = "solid"
         self._color = None
         self._thickness = 1
         self._type = annotation_type
@@ -319,7 +324,7 @@ class Annotation:
 
     @property
     def border_style(self) -> str:
-        """Border style; valid values: '' (solid), '2,2' (dotted), '4,2' (dashed).
+        """Border style; valid values: solid, dotted, dashed.
 
         :returns: The border style string.
         """
@@ -329,12 +334,14 @@ class Annotation:
     @border_style.setter
     @locked
     def border_style(self, value: str) -> None:
-        """Set border style; valid values: '' (solid), '2,2' (dotted), '4,2' (dashed).
+        """Set border style (solid, dotted, dashed).
 
         :param value: The border style string to set.
         """
-        self._set_annotation_property("border_style", value)
-        self._border_style = value
+        canonical = BorderStyle(value).value
+        wire = border_style_for_api(canonical, self._session.controller_version)
+        self._set_annotation_property("border_style", wire)
+        self._border_style = canonical
 
     @property
     def color(self) -> str:
@@ -547,13 +554,24 @@ class Annotation:
                 raise InvalidProperty(f"Invalid annotation property: {key}")
 
         if push_to_server:
-            self._set_annotation_properties(annotation_data)
+            wire_data = dict(annotation_data)
+            if "border_style" in wire_data:
+                wire_data["border_style"] = border_style_for_api(
+                    wire_data["border_style"],
+                    self._session.controller_version,
+                )
+            self._set_annotation_properties(wire_data)
 
         # update locally
-        for key, value in annotation_data.items():
+        for key, raw_value in annotation_data.items():
             if key == "id":
                 continue
-            setattr(self, f"_{key}", value)
+            local_value = (
+                border_style_from_api(raw_value, self._session.controller_version)
+                if key == "border_style"
+                else raw_value
+            )
+            setattr(self, f"_{key}", local_value)
 
     def _set_annotation_property(self, key: str, val: Any) -> None:
         """

--- a/virl2_client/models/border_style.py
+++ b/virl2_client/models/border_style.py
@@ -1,0 +1,46 @@
+#
+# This file is part of VIRL 2
+# Copyright (c) 2019-2026, Cisco Systems, Inc.
+# All rights reserved.
+#
+"""Convert annotation border_style between canonical and legacy wire formats."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from ..utils import Version
+
+CANONICAL_BORDER_STYLE_MIN_VERSION = Version("2.11.0")
+
+
+class BorderStyle(str, Enum):
+    """Canonical annotation border styles (mirrors simple_common.schemas.enums.BorderStyle)."""
+
+    SOLID = "solid"
+    DOTTED = "dotted"
+    DASHED = "dashed"
+
+
+_LEGACY_TO_CANONICAL: dict[str, str] = {
+    "": BorderStyle.SOLID.value,
+    "2,2": BorderStyle.DOTTED.value,
+    "4,2": BorderStyle.DASHED.value,
+}
+
+_CANONICAL_TO_LEGACY: dict[str, str] = {v: k for k, v in _LEGACY_TO_CANONICAL.items()}
+
+
+def border_style_from_api(value: str, controller_version: Version) -> str:
+    """Parse a border_style value returned by the connected controller."""
+    if controller_version >= CANONICAL_BORDER_STYLE_MIN_VERSION:
+        return BorderStyle(value).value
+    return _LEGACY_TO_CANONICAL[value]
+
+
+def border_style_for_api(value: str, controller_version: Version) -> str:
+    """Serialize a canonical border style for the connected controller API."""
+    canonical = BorderStyle(value).value
+    if controller_version >= CANONICAL_BORDER_STYLE_MIN_VERSION:
+        return canonical
+    return _CANONICAL_TO_LEGACY[canonical]

--- a/virl2_client/models/smart_annotation.py
+++ b/virl2_client/models/smart_annotation.py
@@ -26,6 +26,11 @@ from typing import TYPE_CHECKING, Any, ClassVar
 from ..exceptions import InvalidProperty
 from ..utils import check_stale, get_url_from_template, locked
 from ..utils import property_s as property
+from .border_style import (
+    BorderStyle,
+    border_style_for_api,
+    border_style_from_api,
+)
 
 if TYPE_CHECKING:
     import httpx
@@ -43,7 +48,7 @@ _SMART_ANNOTATION_DEFAULTS = {
     "tag_size": 14,
     "group_distance": 400,
     "thickness": 1,
-    "border_style": "",
+    "border_style": "solid",
     "fill_color": None,  # randomly generated
     "border_color": "#00000080",
     "z_index": 1,
@@ -319,7 +324,7 @@ class SmartAnnotation:
 
     @property
     def border_style(self) -> str:
-        """Border style; valid values: '' (solid), '2,2' (dotted), '4,2' (dashed).
+        """Border style; valid values: solid, dotted, dashed.
 
         :returns: The border style string.
         """
@@ -329,12 +334,14 @@ class SmartAnnotation:
     @border_style.setter
     @locked
     def border_style(self, value: str) -> None:
-        """Set border style; valid values: '' (solid), '2,2' (dotted), '4,2' (dashed).
+        """Set border style (solid, dotted, dashed).
 
         :param value: The border style string to set.
         """
-        self._set_smart_annotation_property("border_style", value)
-        self._border_style = value
+        canonical = BorderStyle(value).value
+        wire = border_style_for_api(canonical, self._session.controller_version)
+        self._set_smart_annotation_property("border_style", wire)
+        self._border_style = canonical
 
     @property
     def fill_color(self) -> str | None:
@@ -460,13 +467,24 @@ class SmartAnnotation:
                 raise InvalidProperty(f"Invalid smart annotation property: {key}")
 
         if push_to_server:
-            self._set_smart_annotation_properties(annotation_data)
+            wire_data = dict(annotation_data)
+            if "border_style" in wire_data:
+                wire_data["border_style"] = border_style_for_api(
+                    wire_data["border_style"],
+                    self._session.controller_version,
+                )
+            self._set_smart_annotation_properties(wire_data)
 
         # update locally
-        for key, value in annotation_data.items():
+        for key, raw_value in annotation_data.items():
             if key == "id":
                 continue
-            setattr(self, f"_{key}", value)
+            local_value = (
+                border_style_from_api(raw_value, self._session.controller_version)
+                if key == "border_style"
+                else raw_value
+            )
+            setattr(self, f"_{key}", local_value)
 
     def _set_smart_annotation_property(self, key: str, val: Any) -> None:
         """


### PR DESCRIPTION
### Summary

Update `virl2_client` annotation `border_style` to use canonical `solid`, `dotted`, and `dashed` in the client API while version-gating wire encoding to connected controllers.

### Fix

- Client setters accept canonical values only (`BorderStyle` enum).
- **2.10 controllers:** wire uses legacy `""` / `"2,2"` / `"4,2"`.
- **2.11+ controllers:** wire stays canonical.
- Inbound API responses are normalized to canonical on read.